### PR TITLE
fix(site): deduplicate GitHub icon and improve mobile nav layout

### DIFF
--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -7,13 +7,13 @@ const prefix = isHome ? '' : '/';
 const isDocs = Astro.url.pathname === '/docs' || Astro.url.pathname.startsWith('/docs/');
 ---
 <nav aria-label="Main navigation" class="fixed top-0 left-0 right-0 z-50 border-b border-outline-variant bg-surface/80 backdrop-blur-md">
-  <div class={`nav-inner mx-auto px-6 flex items-center justify-between h-16 ${isHome ? 'max-w-[1200px]' : 'max-w-[1280px]'}`}>
-    <!-- Logo -->
+  <div class={`nav-inner mx-auto px-6 flex items-center justify-center lg:justify-between h-16 ${isHome ? 'max-w-[1200px]' : 'max-w-[1280px]'}`}>
+    <!-- Logo — centered on mobile, left-aligned on desktop -->
     <a href="/" class="font-mono text-lg font-bold text-on-surface tracking-tight">
       mantle<span class="text-primary">_</span>
     </a>
 
-    <!-- Center links (hidden on mobile) -->
+    <!-- Center links (hidden on mobile) — acts as middle section on desktop -->
     <div class="hidden md:flex items-center gap-8">
       <a href={`${prefix}#how-it-works`} class="text-sm text-on-surface-variant hover:text-on-surface transition-colors">How It Works</a>
       <a href={`${prefix}#connectors`} class="text-sm text-on-surface-variant hover:text-on-surface transition-colors">Connectors</a>
@@ -23,7 +23,7 @@ const isDocs = Astro.url.pathname === '/docs' || Astro.url.pathname.startsWith('
 
     <!-- Right side -->
     <div class="flex items-center gap-4">
-      <a href="https://github.com/dvflw/mantle" target="_blank" rel="noopener" class="text-on-surface-variant hover:text-on-surface transition-colors" aria-label="GitHub">
+      <a href="https://github.com/dvflw/mantle" target="_blank" rel="noopener" class="hidden lg:block text-on-surface-variant hover:text-on-surface transition-colors" aria-label="GitHub">
         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
       </a>
       <a href={`${prefix}#get-started`} class="hidden sm:inline-flex px-4 py-2 bg-primary text-on-primary text-sm font-medium hover:bg-primary-dim transition-colors">
@@ -41,12 +41,6 @@ const isDocs = Astro.url.pathname === '/docs' || Astro.url.pathname.startsWith('
       <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955a1.126 1.126 0 011.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/></svg>
       <span>Home</span>
     </a>
-    {isDocs && (
-      <button id="bottom-nav-docs-btn" class="bottom-nav-item flex flex-col items-center gap-0.5 px-3 py-1 text-[11px] text-on-surface-variant hover:text-on-surface transition-colors" aria-label="Documentation menu">
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"/></svg>
-        <span>Menu</span>
-      </button>
-    )}
     <a href="/docs/getting-started" class:list={["bottom-nav-item flex flex-col items-center gap-0.5 px-3 py-1 text-[11px] transition-colors", isDocs ? "text-primary" : "text-on-surface-variant hover:text-on-surface"]}>
       <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/></svg>
       <span>Docs</span>
@@ -55,6 +49,12 @@ const isDocs = Astro.url.pathname === '/docs' || Astro.url.pathname.startsWith('
       <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
       <span>GitHub</span>
     </a>
+    {isDocs && (
+      <button id="bottom-nav-docs-btn" class="bottom-nav-item flex flex-col items-center gap-0.5 px-3 py-1 text-[11px] text-on-surface-variant hover:text-on-surface transition-colors" aria-label="Documentation menu">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"/></svg>
+        <span>Menu</span>
+      </button>
+    )}
   </div>
 </nav>
 


### PR DESCRIPTION
## Summary
- Hide top-bar GitHub icon on mobile (`lg:hidden`) — the bottom bar already has one
- Center the logo in the top bar on mobile (`justify-center lg:justify-between`)
- Move the Menu button to the far right of the bottom bar for better thumb reachability

## Bottom bar order (mobile)
`Home | Docs | GitHub | Menu`

Previously Menu was between Home and Docs, which felt awkward. Moving it to the far right puts it at the natural thumb position.

## Test plan
- [ ] Verify GitHub icon appears once on mobile (bottom bar only)
- [ ] Verify GitHub icon appears in both bars on desktop (lg+)
- [ ] Verify logo is centered in top bar on mobile
- [ ] Verify Menu button is rightmost item in bottom bar on docs pages
- [ ] Verify sidebar toggle still works from the Menu button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved responsive header layout: logo now centers on mobile devices while maintaining proper alignment on larger screens.
  * Adjusted GitHub link visibility to display only on larger screens for a cleaner mobile experience.
  * Reorganized navigation menu structure for better usability across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->