### PR TITLE
feat(env): audit events, update cmd, secret redaction, richer plan --env

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,19 @@ mantle logs <execution-id>    # View execution logs
 mantle status <execution-id>  # View execution state
 mantle secrets create         # Create typed credential
 mantle secrets rotate-key     # Re-encrypt credentials with new key
+mantle env create <name>      # Create a named environment from a values file
+mantle env update <name>      # Replace inputs/env on an existing environment
+mantle env list               # List named environments
+mantle env get <name>         # Show environment details (env values redacted; --reveal to unredact, audited)
+mantle env delete <name> -y   # Delete a named environment (requires --yes)
+mantle run <wf> --values f.yaml   # Run with a values file (inputs + env overrides)
+mantle run <wf> --env <name>      # Run against a stored named environment
+mantle plan <wf> --env <name>     # Plan; appends resolved inputs/env with source
 mantle serve                  # Start persistent server
 ```
+
+**Override precedence (highest wins):**
+`MANTLE_ENV_*` OS vars > `--input` flags > `--values` file > `--env` named environment > workflow `default` values > config `env:` section
 
 ## License
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,10 @@ mantle plan <wf> --env <name>     # Plan; appends resolved inputs/env with sourc
 mantle serve                  # Start persistent server
 ```
 
-**Override precedence (highest wins):**
-`MANTLE_ENV_*` OS vars > `--input` flags > `--values` file > `--env` named environment > workflow `default` values > config `env:` section
+**Override precedence (highest wins).** Inputs and env vars resolve in separate namespaces:
+
+- **Workflow inputs** (consumed by `inputs.<name>` in CEL): `--input` flags > `--values` file `inputs:` > `--env` named-environment `inputs` > workflow definition `default`
+- **Env vars** (consumed by `env.<KEY>` in CEL): `MANTLE_ENV_*` OS vars > `--values` file `env:` > `--env` named-environment `env` > config `env:` section in `mantle.yaml`
 
 ## License
 

--- a/packages/engine/internal/audit/audit.go
+++ b/packages/engine/internal/audit/audit.go
@@ -55,6 +55,12 @@ const (
 
 	// Rollback operations.
 	ActionWorkflowRolledBack Action = "workflow.rolled_back"
+
+	// Environment operations.
+	ActionEnvironmentCreated  Action = "environment.created"
+	ActionEnvironmentUpdated  Action = "environment.updated"
+	ActionEnvironmentDeleted  Action = "environment.deleted"
+	ActionEnvironmentRevealed Action = "environment.revealed"
 )
 
 // Resource identifies the target of an audit event.

--- a/packages/engine/internal/cel/cel.go
+++ b/packages/engine/internal/cel/cel.go
@@ -233,9 +233,10 @@ func (e *Evaluator) SetConfigEnv(configEnv map[string]string) {
 	e.envCache = mergeEnvVars(configEnv, e.valuesEnv)
 }
 
-// SetValuesEnv sets the values-file env overrides and rebuilds the env cache.
-// Values-file env sits between config env and MANTLE_ENV_* OS variables in
-// the precedence stack: config < values < MANTLE_ENV_*.
+// SetValuesEnv sets the values-file and named-environment env overrides
+// and rebuilds the env cache. Overlays them on top of config env; MANTLE_ENV_*
+// OS vars still win. The layered precedence is config < values/named-env <
+// MANTLE_ENV_*.
 func (e *Evaluator) SetValuesEnv(valuesEnv map[string]string) {
 	e.valuesEnv = valuesEnv
 	e.envCache = mergeEnvVars(e.configEnv, e.valuesEnv)

--- a/packages/engine/internal/cli/env.go
+++ b/packages/engine/internal/cli/env.go
@@ -121,6 +121,8 @@ func runEnvWrite(cmd *cobra.Command, name, fromFile string, mode envWriteMode) e
 	case writeModeUpdate:
 		e, err = store.Update(cmd.Context(), name, vals.Inputs, vals.Env)
 		verb = "Updated"
+	default:
+		return fmt.Errorf("unknown env write mode: %d", mode)
 	}
 	if err != nil {
 		return err

--- a/packages/engine/internal/cli/env.go
+++ b/packages/engine/internal/cli/env.go
@@ -12,17 +12,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// redactedPlaceholder is printed in place of env values in `env get` output
+// unless --reveal is passed. Values files commonly contain secret-shaped
+// material (API keys, connection strings, tokens) and must not leak to logs
+// or terminal scrollback by default. Revealing is always audited.
+const redactedPlaceholder = "<redacted>"
+
 // newEnvCommand returns the "env" subcommand for managing named environments.
 func newEnvCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "env",
 		Short: "Manage named environments",
-		Long:  "Create, list, show, and delete named environments for parameterized workflow execution.",
+		Long: `Named environments (e.g., "production", "staging") store reusable input
+and env variable sets for parameterized workflow runs. Combine with
+` + "`mantle run --env <name>`" + ` and ` + "`mantle plan --env <name>`" + ` to promote the
+same workflow across environments without rewriting CLI flags.
+
+Override precedence (highest wins):
+  --input flags > --values file > --env named environment > workflow defaults`,
 	}
 
 	cmd.AddCommand(newEnvCreateCommand())
+	cmd.AddCommand(newEnvUpdateCommand())
 	cmd.AddCommand(newEnvListCommand())
-	cmd.AddCommand(newEnvShowCommand())
+	cmd.AddCommand(newEnvGetCommand())
 	cmd.AddCommand(newEnvDeleteCommand())
 
 	return cmd
@@ -36,31 +49,15 @@ func newEnvCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create a named environment",
-		Long:  "Creates a named environment from a values file.",
+		Long: `Creates a named environment from a YAML values file. The file must
+contain top-level ` + "`inputs:`" + ` and/or ` + "`env:`" + ` keys. Names must match
+[a-z0-9][a-z0-9_-]*. Fails if an environment with the same name already
+exists in the team scope; use ` + "`mantle env update`" + ` to replace it.`,
 		Example: `  mantle env create production --from prod.values.yaml
   mantle env create staging --from staging.values.yaml`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			name := args[0]
-
-			vals, err := workflow.LoadValues(fromFile)
-			if err != nil {
-				return fmt.Errorf("loading values file: %w", err)
-			}
-
-			store, cleanup, err := newEnvStore(cmd)
-			if err != nil {
-				return err
-			}
-			defer cleanup()
-
-			env, err := store.Create(cmd.Context(), name, vals.Inputs, vals.Env)
-			if err != nil {
-				return err
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "Created environment %q\n", env.Name)
-			return nil
+			return runEnvWrite(cmd, args[0], fromFile, writeModeCreate)
 		},
 	}
 
@@ -70,13 +67,80 @@ func newEnvCreateCommand() *cobra.Command {
 	return cmd
 }
 
+// newEnvUpdateCommand returns the "env update" subcommand, which replaces the
+// stored inputs and env on an existing named environment.
+func newEnvUpdateCommand() *cobra.Command {
+	var fromFile string
+
+	cmd := &cobra.Command{
+		Use:   "update <name>",
+		Short: "Update an existing named environment",
+		Long: `Replaces the inputs and env of an existing environment with the contents
+of a values file. Preserves the environment ID, creation timestamp, and audit
+history. Fails if the environment does not exist.`,
+		Example: `  mantle env update production --from prod.values.yaml`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEnvWrite(cmd, args[0], fromFile, writeModeUpdate)
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from", "", "Values file to load inputs and env from (required)")
+	_ = cmd.MarkFlagRequired("from")
+
+	return cmd
+}
+
+type envWriteMode int
+
+const (
+	writeModeCreate envWriteMode = iota
+	writeModeUpdate
+)
+
+// runEnvWrite is the shared body for create/update: load a values file,
+// dispatch to the matching Store method, and print a single-line confirmation.
+func runEnvWrite(cmd *cobra.Command, name, fromFile string, mode envWriteMode) error {
+	vals, err := workflow.LoadValues(fromFile)
+	if err != nil {
+		return fmt.Errorf("loading values file: %w", err)
+	}
+
+	store, cleanup, err := newEnvStore(cmd)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	var e *environment.Environment
+	var verb string
+	switch mode {
+	case writeModeCreate:
+		e, err = store.Create(cmd.Context(), name, vals.Inputs, vals.Env)
+		verb = "Created"
+	case writeModeUpdate:
+		e, err = store.Update(cmd.Context(), name, vals.Inputs, vals.Env)
+		verb = "Updated"
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "%s environment %q\n", verb, e.Name)
+	return nil
+}
+
 // newEnvListCommand returns the "env list" subcommand, which prints all named
-// environments for the current team.
+// environments for the current team with their creation and update timestamps.
 func newEnvListCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "List all environments",
-		Args:  cobra.NoArgs,
+		Short: "List all named environments",
+		Long: `Lists every environment in the current team scope with creation and
+update timestamps. Raw input and env values are never shown here — use
+` + "`mantle env get <name> --reveal`" + ` to view them.`,
+		Example: `  mantle env list`,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store, cleanup, err := newEnvStore(cmd)
 			if err != nil {
@@ -95,22 +159,35 @@ func newEnvListCommand() *cobra.Command {
 			}
 
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "NAME\tCREATED")
+			fmt.Fprintln(w, "NAME\tCREATED\tUPDATED")
 			for _, e := range envs {
-				fmt.Fprintf(w, "%s\t%s\n", e.Name, e.CreatedAt.UTC().Format("2006-01-02 15:04:05 UTC"))
+				fmt.Fprintf(w, "%s\t%s\t%s\n",
+					e.Name,
+					e.CreatedAt.UTC().Format("2006-01-02 15:04:05 UTC"),
+					e.UpdatedAt.UTC().Format("2006-01-02 15:04:05 UTC"),
+				)
 			}
 			return w.Flush()
 		},
 	}
 }
 
-// newEnvShowCommand returns the "env show" subcommand, which prints the inputs
-// and env vars stored in a named environment.
-func newEnvShowCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "show <name>",
+// newEnvGetCommand returns the "env get" subcommand, which prints the stored
+// inputs and env for a named environment. Env values are redacted unless the
+// caller passes --reveal, which emits an environment.revealed audit event.
+func newEnvGetCommand() *cobra.Command {
+	var reveal bool
+
+	cmd := &cobra.Command{
+		Use:   "get <name>",
 		Short: "Show environment details",
-		Args:  cobra.ExactArgs(1),
+		Long: `Shows the stored inputs and env for a named environment along with its
+timestamps. Env values are redacted by default because values files often
+contain secret-shaped material. Pass --reveal to print raw values; every
+reveal emits an ` + "`environment.revealed`" + ` audit event.`,
+		Example: `  mantle env get production
+  mantle env get production --reveal`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store, cleanup, err := newEnvStore(cmd)
 			if err != nil {
@@ -123,42 +200,63 @@ func newEnvShowCommand() *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Name: %s\n", env.Name)
-			if len(env.Inputs) > 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "\nInputs:")
-				keys := make([]string, 0, len(env.Inputs))
-				for k := range env.Inputs {
-					keys = append(keys, k)
+			if reveal {
+				if revealErr := store.EmitReveal(cmd.Context(), env); revealErr != nil {
+					return fmt.Errorf("recording reveal audit event: %w", revealErr)
 				}
-				sort.Strings(keys)
-				for _, k := range keys {
-					fmt.Fprintf(cmd.OutOrStdout(), "  %s: %v\n", k, env.Inputs[k])
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Name:       %s\n", env.Name)
+			fmt.Fprintf(out, "ID:         %s\n", env.ID)
+			fmt.Fprintf(out, "Created:    %s\n", env.CreatedAt.UTC().Format("2006-01-02 15:04:05 UTC"))
+			fmt.Fprintf(out, "Updated:    %s\n", env.UpdatedAt.UTC().Format("2006-01-02 15:04:05 UTC"))
+
+			if len(env.Inputs) > 0 {
+				fmt.Fprintln(out, "\nInputs:")
+				for _, k := range sortedKeys(env.Inputs) {
+					fmt.Fprintf(out, "  %s: %v\n", k, env.Inputs[k])
 				}
 			}
 			if len(env.Env) > 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "\nEnv:")
-				keys := make([]string, 0, len(env.Env))
-				for k := range env.Env {
-					keys = append(keys, k)
+				fmt.Fprintln(out, "\nEnv:")
+				for _, k := range sortedStringKeys(env.Env) {
+					if reveal {
+						fmt.Fprintf(out, "  %s: %s\n", k, env.Env[k])
+					} else {
+						fmt.Fprintf(out, "  %s: %s\n", k, redactedPlaceholder)
+					}
 				}
-				sort.Strings(keys)
-				for _, k := range keys {
-					fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", k, env.Env[k])
+				if !reveal {
+					fmt.Fprintln(out, "\n(Env values redacted. Pass --reveal to display; reveals are audited.)")
 				}
 			}
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&reveal, "reveal", false, "Print raw env values (emits an environment.revealed audit event)")
+	return cmd
 }
 
-// newEnvDeleteCommand returns the "env delete" subcommand, which removes a
-// named environment from the database.
+// newEnvDeleteCommand returns the "env delete" subcommand, which permanently
+// removes a named environment. Requires --yes to confirm.
 func newEnvDeleteCommand() *cobra.Command {
-	return &cobra.Command{
+	var yes bool
+
+	cmd := &cobra.Command{
 		Use:   "delete <name>",
 		Short: "Delete an environment",
-		Args:  cobra.ExactArgs(1),
+		Long: `Permanently deletes a named environment. Requires --yes to confirm
+because deletion cannot be undone from the CLI — referring workflow runs will
+fail until the environment is recreated.`,
+		Example: `  mantle env delete staging --yes`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !yes {
+				return fmt.Errorf("refusing to delete %q without --yes", args[0])
+			}
+
 			store, cleanup, err := newEnvStore(cmd)
 			if err != nil {
 				return err
@@ -173,6 +271,9 @@ func newEnvDeleteCommand() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Confirm deletion (required)")
+	return cmd
 }
 
 // newEnvStore builds an environment.Store from the current command context.
@@ -187,7 +288,29 @@ func newEnvStore(cmd *cobra.Command) (*environment.Store, func(), error) {
 		return nil, nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 
-	store := &environment.Store{DB: database}
+	store := &environment.Store{DB: database, Actor: "cli"}
 	cleanup := func() { database.Close() }
 	return store, cleanup, nil
+}
+
+// sortedKeys returns the keys of m in ascending order. Used for deterministic
+// output in env get.
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// sortedStringKeys returns the keys of m in ascending order. Used for
+// deterministic output in env get.
+func sortedStringKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/packages/engine/internal/cli/plan.go
+++ b/packages/engine/internal/cli/plan.go
@@ -169,16 +169,22 @@ func writeResolvedOverrides(
 		}
 	}
 
-	envs := workflow.ResolveEnvVars(configEnv, envEnvVars, valuesEnv)
-	if len(envs) > 0 {
-		fmt.Fprintln(w, "  Env vars:")
-		keys := make([]string, 0, len(envs))
-		for k := range envs {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			fmt.Fprintf(w, "    %s = %q  (from: %s)\n", k, envs[k].Value, envs[k].Source)
+	// Mirror the Inputs gating: only emit the Env vars block when the operator
+	// actually supplied env overrides via --env or --values. Otherwise
+	// ResolveEnvVars would surface the config env: section alone, which isn't
+	// a product of the command being planned.
+	if envEnvVars != nil || valuesEnv != nil {
+		envs := workflow.ResolveEnvVars(configEnv, envEnvVars, valuesEnv)
+		if len(envs) > 0 {
+			fmt.Fprintln(w, "  Env vars:")
+			keys := make([]string, 0, len(envs))
+			for k := range envs {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				fmt.Fprintf(w, "    %s = %q  (from: %s)\n", k, envs[k].Value, envs[k].Source)
+			}
 		}
 	}
 

--- a/packages/engine/internal/cli/plan.go
+++ b/packages/engine/internal/cli/plan.go
@@ -5,7 +5,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"sort"
 
 	"github.com/dvflw/mantle/internal/config"
 	"github.com/dvflw/mantle/internal/db"
@@ -21,8 +23,12 @@ func newPlanCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plan <file>",
 		Short: "Show what will change",
-		Long:  "Diffs a local workflow definition against the currently applied version and shows what will change.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Diffs a local workflow definition against the currently applied version
+and shows what will change. When --values or --env is supplied, the resolved
+input values and env variables that the next run would use are appended to
+the output along with their source layer — useful for verifying promotion
+targets in CI before apply.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			filename := args[0]
 
@@ -31,12 +37,15 @@ func newPlanCommand() *cobra.Command {
 				return fmt.Errorf("config not loaded")
 			}
 
-			// Load values file early so we fail fast on bad input.
+			var valuesInputs map[string]any
+			var valuesEnv map[string]string
 			if valuesFile != "" {
-				_, valErr := workflow.LoadValues(valuesFile)
+				vals, valErr := workflow.LoadValues(valuesFile)
 				if valErr != nil {
 					return fmt.Errorf("loading values file: %w", valErr)
 				}
+				valuesInputs = vals.Inputs
+				valuesEnv = vals.Env
 			}
 
 			database, err := db.Open(cfg.Database)
@@ -45,11 +54,16 @@ func newPlanCommand() *cobra.Command {
 			}
 			defer database.Close()
 
+			var envInputs map[string]any
+			var envEnvVars map[string]string
 			if envName != "" {
-				envStore := &environment.Store{DB: database}
-				if _, envErr := envStore.Get(cmd.Context(), envName); envErr != nil {
+				envStore := &environment.Store{DB: database, Actor: "cli"}
+				storedEnv, envErr := envStore.Get(cmd.Context(), envName)
+				if envErr != nil {
 					return fmt.Errorf("resolving environment %q: %w", envName, envErr)
 				}
+				envInputs = storedEnv.Inputs
+				envEnvVars = storedEnv.Env
 			}
 
 			rawContent, err := os.ReadFile(filename)
@@ -69,21 +83,21 @@ func newPlanCommand() *cobra.Command {
 
 			name := result.Workflow.Name
 
-			// Fetch latest stored version.
 			storedContent, storedVersion, err := workflow.GetLatestContent(cmd.Context(), database, name)
 			if err != nil {
 				return fmt.Errorf("fetching latest version: %w", err)
 			}
 
-			// New workflow — no prior version.
+			out := cmd.OutOrStdout()
+
 			if storedContent == nil {
 				diff := workflow.Diff(nil, result.Workflow)
-				fmt.Fprint(cmd.OutOrStdout(), diff)
-				fmt.Fprintf(cmd.OutOrStdout(), "\nPlan: 1 workflow to create\n")
+				fmt.Fprint(out, diff)
+				fmt.Fprintf(out, "\nPlan: 1 workflow to create\n")
+				writeResolvedOverrides(out, result.Workflow.Inputs, envInputs, valuesInputs, cfg.Env, envEnvVars, valuesEnv)
 				return nil
 			}
 
-			// Check if content is unchanged.
 			h := sha256.Sum256(rawContent)
 			newHash := hex.EncodeToString(h[:])
 			storedHash, err := workflow.GetLatestHash(cmd.Context(), database, name)
@@ -91,11 +105,11 @@ func newPlanCommand() *cobra.Command {
 				return fmt.Errorf("fetching hash: %w", err)
 			}
 			if newHash == storedHash {
-				fmt.Fprintf(cmd.OutOrStdout(), "No changes — %s is at version %d\n", name, storedVersion)
+				fmt.Fprintf(out, "No changes — %s is at version %d\n", name, storedVersion)
+				writeResolvedOverrides(out, result.Workflow.Inputs, envInputs, valuesInputs, cfg.Env, envEnvVars, valuesEnv)
 				return nil
 			}
 
-			// Diff against stored version.
 			var oldWorkflow workflow.Workflow
 			if err := json.Unmarshal(storedContent, &oldWorkflow); err != nil {
 				return fmt.Errorf("unmarshaling stored workflow: %w", err)
@@ -103,17 +117,64 @@ func newPlanCommand() *cobra.Command {
 
 			diff := workflow.Diff(&oldWorkflow, result.Workflow)
 			if diff == "" {
-				fmt.Fprintf(cmd.OutOrStdout(), "No changes — %s is at version %d\n", name, storedVersion)
+				fmt.Fprintf(out, "No changes — %s is at version %d\n", name, storedVersion)
+				writeResolvedOverrides(out, result.Workflow.Inputs, envInputs, valuesInputs, cfg.Env, envEnvVars, valuesEnv)
 				return nil
 			}
 
-			fmt.Fprint(cmd.OutOrStdout(), diff)
-			fmt.Fprintf(cmd.OutOrStdout(), "\nPlan: 1 workflow to update (version %d → %d)\n", storedVersion, storedVersion+1)
+			fmt.Fprint(out, diff)
+			fmt.Fprintf(out, "\nPlan: 1 workflow to update (version %d → %d)\n", storedVersion, storedVersion+1)
+			writeResolvedOverrides(out, result.Workflow.Inputs, envInputs, valuesInputs, cfg.Env, envEnvVars, valuesEnv)
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&valuesFile, "values", "", "Validate a values file (does not affect diff output)")
-	cmd.Flags().StringVar(&envName, "env", "", "Validate that a named environment exists (does not affect diff output)")
+	cmd.Flags().StringVar(&valuesFile, "values", "", "Values file with input and env overrides (YAML). When set, plan appends the resolved configuration.")
+	cmd.Flags().StringVar(&envName, "env", "", "Named environment to apply. When set, plan appends the resolved configuration and its source per value.")
 	return cmd
+}
+
+// writeResolvedOverrides appends a "Resolved configuration" block showing the
+// final inputs and env vars the next run would see. Only writes if at least
+// one override layer was provided.
+func writeResolvedOverrides(
+	w io.Writer,
+	workflowInputs map[string]workflow.Input,
+	envInputs map[string]any,
+	valuesInputs map[string]any,
+	configEnv, envEnvVars, valuesEnv map[string]string,
+) {
+	if envInputs == nil && valuesInputs == nil && envEnvVars == nil && valuesEnv == nil {
+		return
+	}
+
+	fmt.Fprintln(w, "\nResolved configuration:")
+
+	inputs := workflow.ResolveInputs(workflowInputs, envInputs, valuesInputs, nil)
+	if len(inputs) > 0 {
+		fmt.Fprintln(w, "  Inputs:")
+		keys := make([]string, 0, len(inputs))
+		for k := range inputs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(w, "    %s = %v  (from: %s)\n", k, inputs[k].Value, inputs[k].Source)
+		}
+	}
+
+	envs := workflow.ResolveEnvVars(configEnv, envEnvVars, valuesEnv)
+	if len(envs) > 0 {
+		fmt.Fprintln(w, "  Env vars:")
+		keys := make([]string, 0, len(envs))
+		for k := range envs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(w, "    %s = %q  (from: %s)\n", k, envs[k].Value, envs[k].Source)
+		}
+	}
+
+	fmt.Fprintln(w, "  (Inline --input flags, if any, would override these at run time. MANTLE_ENV_* OS vars override at run time too.)")
 }

--- a/packages/engine/internal/cli/plan.go
+++ b/packages/engine/internal/cli/plan.go
@@ -150,16 +150,22 @@ func writeResolvedOverrides(
 
 	fmt.Fprintln(w, "\nResolved configuration:")
 
-	inputs := workflow.ResolveInputs(workflowInputs, envInputs, valuesInputs, nil)
-	if len(inputs) > 0 {
-		fmt.Fprintln(w, "  Inputs:")
-		keys := make([]string, 0, len(inputs))
-		for k := range inputs {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			fmt.Fprintf(w, "    %s = %v  (from: %s)\n", k, inputs[k].Value, inputs[k].Source)
+	// Only emit the Inputs block when the operator actually supplied input
+	// overrides. Otherwise ResolveInputs would seed the block with workflow
+	// defaults and pad CI logs with content that isn't a product of --env or
+	// --values.
+	if envInputs != nil || valuesInputs != nil {
+		inputs := workflow.ResolveInputs(workflowInputs, envInputs, valuesInputs, nil)
+		if len(inputs) > 0 {
+			fmt.Fprintln(w, "  Inputs:")
+			keys := make([]string, 0, len(inputs))
+			for k := range inputs {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				fmt.Fprintf(w, "    %s = %v  (from: %s)\n", k, inputs[k].Value, inputs[k].Source)
+			}
 		}
 	}
 

--- a/packages/engine/internal/cli/plan_test.go
+++ b/packages/engine/internal/cli/plan_test.go
@@ -60,3 +60,35 @@ func TestWriteResolvedOverrides_ValuesOnly(t *testing.T) {
 		t.Errorf("expected values source attribution, got: %s", out)
 	}
 }
+
+func TestWriteResolvedOverrides_EnvVarsOnlyOmitsInputsBlock(t *testing.T) {
+	wfInputs := map[string]workflow.Input{
+		"url": {Type: "string", Default: "https://default.example.com"},
+	}
+	envEnvVars := map[string]string{"REGION": "eu-west-1"}
+
+	var buf bytes.Buffer
+	writeResolvedOverrides(&buf, wfInputs, nil, nil, nil, envEnvVars, nil)
+	out := buf.String()
+
+	if strings.Contains(out, "Inputs:") {
+		t.Errorf("did not expect Inputs block when only env vars overridden, got:\n%s", out)
+	}
+	if !strings.Contains(out, "REGION = \"eu-west-1\"  (from: env)") {
+		t.Errorf("expected env vars block, got:\n%s", out)
+	}
+}
+
+func TestWriteResolvedOverrides_ConfigEnvUsesTypedSource(t *testing.T) {
+	configEnv := map[string]string{"LOG_LEVEL": "info"}
+	// At least one override layer so the block prints.
+	envEnvVars := map[string]string{"REGION": "us-east-1"}
+
+	var buf bytes.Buffer
+	writeResolvedOverrides(&buf, nil, nil, nil, configEnv, envEnvVars, nil)
+	out := buf.String()
+
+	if !strings.Contains(out, "LOG_LEVEL = \"info\"  (from: config)") {
+		t.Errorf("expected config source attribution for LOG_LEVEL, got:\n%s", out)
+	}
+}

--- a/packages/engine/internal/cli/plan_test.go
+++ b/packages/engine/internal/cli/plan_test.go
@@ -92,3 +92,20 @@ func TestWriteResolvedOverrides_ConfigEnvUsesTypedSource(t *testing.T) {
 		t.Errorf("expected config source attribution for LOG_LEVEL, got:\n%s", out)
 	}
 }
+
+func TestWriteResolvedOverrides_InputsOnlyOmitsEnvBlock(t *testing.T) {
+	valuesInputs := map[string]any{"url": "https://example.com"}
+	// Config env is present but operator only supplied input overrides.
+	configEnv := map[string]string{"LOG_LEVEL": "info"}
+
+	var buf bytes.Buffer
+	writeResolvedOverrides(&buf, nil, nil, valuesInputs, configEnv, nil, nil)
+	out := buf.String()
+
+	if strings.Contains(out, "Env vars:") {
+		t.Errorf("did not expect Env vars block when only inputs overridden, got:\n%s", out)
+	}
+	if !strings.Contains(out, "url = https://example.com  (from: values)") {
+		t.Errorf("expected inputs block, got:\n%s", out)
+	}
+}

--- a/packages/engine/internal/cli/plan_test.go
+++ b/packages/engine/internal/cli/plan_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/dvflw/mantle/internal/workflow"
+)
+
+func TestWriteResolvedOverrides_NoOverrides(t *testing.T) {
+	var buf bytes.Buffer
+	writeResolvedOverrides(&buf, nil, nil, nil, nil, nil, nil)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output when no overrides supplied, got: %q", buf.String())
+	}
+}
+
+func TestWriteResolvedOverrides_ShowsSourcePerValue(t *testing.T) {
+	wfInputs := map[string]workflow.Input{
+		"url":     {Type: "string", Default: "https://default.example.com"},
+		"retries": {Type: "number", Default: 3},
+	}
+	envInputs := map[string]any{
+		"url": "https://env.example.com",
+	}
+	valuesInputs := map[string]any{
+		"retries": 10,
+	}
+	configEnv := map[string]string{"LOG_LEVEL": "info"}
+	envEnvVars := map[string]string{"REGION": "us-east-1"}
+	valuesEnv := map[string]string{"LOG_LEVEL": "debug"}
+
+	var buf bytes.Buffer
+	writeResolvedOverrides(&buf, wfInputs, envInputs, valuesInputs, configEnv, envEnvVars, valuesEnv)
+	out := buf.String()
+
+	checks := []string{
+		"Resolved configuration:",
+		"url = https://env.example.com  (from: env)",
+		"retries = 10  (from: values)",
+		"LOG_LEVEL = \"debug\"  (from: values)",
+		"REGION = \"us-east-1\"  (from: env)",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteResolvedOverrides_ValuesOnly(t *testing.T) {
+	valuesInputs := map[string]any{"name": "staging"}
+
+	var buf bytes.Buffer
+	writeResolvedOverrides(&buf, nil, nil, valuesInputs, nil, nil, nil)
+	out := buf.String()
+
+	if !strings.Contains(out, "name = staging  (from: values)") {
+		t.Errorf("expected values source attribution, got: %s", out)
+	}
+}

--- a/packages/engine/internal/db/migrations/018_environments.sql
+++ b/packages/engine/internal/db/migrations/018_environments.sql
@@ -1,4 +1,12 @@
 -- +goose Up
+-- environments stores named reusable input and env-var override sets for
+-- parameterized workflow runs ("production", "staging", etc.), resolved by
+-- `mantle run --env <name>` and `mantle plan --env <name>`. See issue #53.
+--
+-- The inputs and env JSONB columns are intentionally unconstrained so
+-- workflow authors can store arbitrary structured overrides. Raw env
+-- values are never exposed by the CLI without an explicit --reveal flag,
+-- and every reveal emits an environment.revealed audit event.
 CREATE TABLE environments (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     team_id UUID NOT NULL REFERENCES teams(id) DEFAULT '00000000-0000-0000-0000-000000000001',

--- a/packages/engine/internal/environment/store.go
+++ b/packages/engine/internal/environment/store.go
@@ -13,10 +13,16 @@ import (
 	"github.com/dvflw/mantle/internal/auth"
 )
 
+// maxEnvNameLength caps names at the DNS label limit (RFC 1035). Keeping
+// them short enough to use as metric labels and URL path segments without
+// truncation.
+const maxEnvNameLength = 63
+
 // validEnvNamePattern enforces DNS-label-like names (Kubernetes namespace
 // convention): lowercase alphanumerics, underscores, and hyphens, starting
 // with an alphanumeric. Chosen so names are safe to embed in URLs, log lines,
-// metric labels, and filesystem paths without escaping.
+// metric labels, and filesystem paths without escaping. Length is enforced
+// separately in validateName so the error message can cite the cap.
 var validEnvNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 
 // Environment represents a named set of input and env overrides.
@@ -283,6 +289,9 @@ func (s *Store) EmitReveal(ctx context.Context, e *Environment) error {
 func validateName(name string) error {
 	if name == "" {
 		return fmt.Errorf("environment name is required")
+	}
+	if len(name) > maxEnvNameLength {
+		return fmt.Errorf("invalid environment name %q: length %d exceeds %d-char cap", name, len(name), maxEnvNameLength)
 	}
 	if !validEnvNamePattern.MatchString(name) {
 		return fmt.Errorf("invalid environment name %q: must match %s", name, validEnvNamePattern.String())

--- a/packages/engine/internal/environment/store.go
+++ b/packages/engine/internal/environment/store.go
@@ -4,14 +4,20 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
 
+	"github.com/dvflw/mantle/internal/audit"
 	"github.com/dvflw/mantle/internal/auth"
 )
 
-var validEnvNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+// validEnvNamePattern enforces DNS-label-like names (Kubernetes namespace
+// convention): lowercase alphanumerics, underscores, and hyphens, starting
+// with an alphanumeric. Chosen so names are safe to embed in URLs, log lines,
+// metric labels, and filesystem paths without escaping.
+var validEnvNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 
 // Environment represents a named set of input and env overrides.
 type Environment struct {
@@ -24,32 +30,47 @@ type Environment struct {
 }
 
 // Store handles CRUD operations for named environments in Postgres.
+// Every state-changing method emits an audit event atomically with the write.
 type Store struct {
 	DB *sql.DB
+	// Actor labels audit events emitted by this store (e.g., "cli", "server").
+	// Defaults to "cli" when empty.
+	Actor string
 }
 
-// Create stores a new named environment.
-func (s *Store) Create(ctx context.Context, name string, inputs map[string]any, env map[string]string) (*Environment, error) {
-	if name == "" {
-		return nil, fmt.Errorf("environment name is required")
+func (s *Store) actor() string {
+	if s.Actor == "" {
+		return "cli"
 	}
-	if !validEnvNamePattern.MatchString(name) {
-		return nil, fmt.Errorf("invalid environment name %q: must match %s", name, validEnvNamePattern.String())
+	return s.Actor
+}
+
+// ErrNotFound is returned when a lookup for a named environment does not
+// match a row in the current team scope.
+var ErrNotFound = errors.New("environment not found")
+
+// Create stores a new named environment and emits an audit event in the
+// same transaction.
+func (s *Store) Create(ctx context.Context, name string, inputs map[string]any, env map[string]string) (*Environment, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
 	}
 
 	teamID := auth.TeamIDFromContext(ctx)
 
-	inputsJSON, err := json.Marshal(inputs)
+	inputsJSON, envJSON, err := marshalPayload(inputs, env)
 	if err != nil {
-		return nil, fmt.Errorf("marshaling inputs: %w", err)
-	}
-	envJSON, err := json.Marshal(env)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling env: %w", err)
+		return nil, err
 	}
 
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("starting transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
 	var e Environment
-	err = s.DB.QueryRowContext(ctx,
+	err = tx.QueryRowContext(ctx,
 		`INSERT INTO environments (name, team_id, inputs, env)
 		 VALUES ($1, $2, $3, $4)
 		 RETURNING id, name, created_at, updated_at`,
@@ -59,12 +80,83 @@ func (s *Store) Create(ctx context.Context, name string, inputs map[string]any, 
 		return nil, fmt.Errorf("creating environment %q: %w", name, err)
 	}
 
+	if err := audit.EmitTx(ctx, tx, audit.Event{
+		Timestamp: time.Now(),
+		Actor:     s.actor(),
+		Action:    audit.ActionEnvironmentCreated,
+		Resource:  audit.Resource{Type: "environment", ID: e.ID},
+		TeamID:    teamID,
+		Metadata:  map[string]string{"name": name},
+	}); err != nil {
+		return nil, fmt.Errorf("emitting audit event: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing environment create: %w", err)
+	}
+
 	e.Inputs = inputs
 	e.Env = env
 	return &e, nil
 }
 
-// Get retrieves a named environment by name.
+// Update replaces the inputs and env for an existing named environment,
+// preserving id and created_at. Emits an audit event in the same transaction.
+func (s *Store) Update(ctx context.Context, name string, inputs map[string]any, env map[string]string) (*Environment, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+
+	teamID := auth.TeamIDFromContext(ctx)
+
+	inputsJSON, envJSON, err := marshalPayload(inputs, env)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("starting transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var e Environment
+	err = tx.QueryRowContext(ctx,
+		`UPDATE environments
+		 SET inputs = $3, env = $4, updated_at = NOW()
+		 WHERE name = $1 AND team_id = $2
+		 RETURNING id, name, created_at, updated_at`,
+		name, teamID, inputsJSON, envJSON,
+	).Scan(&e.ID, &e.Name, &e.CreatedAt, &e.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("updating environment %q: %w", name, err)
+	}
+
+	if err := audit.EmitTx(ctx, tx, audit.Event{
+		Timestamp: time.Now(),
+		Actor:     s.actor(),
+		Action:    audit.ActionEnvironmentUpdated,
+		Resource:  audit.Resource{Type: "environment", ID: e.ID},
+		TeamID:    teamID,
+		Metadata:  map[string]string{"name": name},
+	}); err != nil {
+		return nil, fmt.Errorf("emitting audit event: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing environment update: %w", err)
+	}
+
+	e.Inputs = inputs
+	e.Env = env
+	return &e, nil
+}
+
+// Get retrieves a named environment by name. Returns ErrNotFound when no
+// matching row exists in the current team scope.
 func (s *Store) Get(ctx context.Context, name string) (*Environment, error) {
 	teamID := auth.TeamIDFromContext(ctx)
 
@@ -75,8 +167,8 @@ func (s *Store) Get(ctx context.Context, name string) (*Environment, error) {
 		 FROM environments WHERE name = $1 AND team_id = $2`,
 		name, teamID,
 	).Scan(&e.ID, &e.Name, &inputsJSON, &envJSON, &e.CreatedAt, &e.UpdatedAt)
-	if err == sql.ErrNoRows {
-		return nil, fmt.Errorf("environment %q not found", name)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %q", ErrNotFound, name)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("querying environment: %w", err)
@@ -121,25 +213,91 @@ func (s *Store) List(ctx context.Context) ([]Environment, error) {
 	return envs, rows.Err()
 }
 
-// Delete removes a named environment.
+// Delete removes a named environment and emits an audit event in the same
+// transaction. Returns ErrNotFound when no matching row exists.
 func (s *Store) Delete(ctx context.Context, name string) error {
 	teamID := auth.TeamIDFromContext(ctx)
 
-	result, err := s.DB.ExecContext(ctx,
-		`DELETE FROM environments WHERE name = $1 AND team_id = $2`,
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("starting transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var deletedID string
+	err = tx.QueryRowContext(ctx,
+		`DELETE FROM environments WHERE name = $1 AND team_id = $2 RETURNING id`,
 		name, teamID,
-	)
+	).Scan(&deletedID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
 	if err != nil {
 		return fmt.Errorf("deleting environment %q: %w", name, err)
 	}
 
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("checking delete result: %w", err)
+	if err := audit.EmitTx(ctx, tx, audit.Event{
+		Timestamp: time.Now(),
+		Actor:     s.actor(),
+		Action:    audit.ActionEnvironmentDeleted,
+		Resource:  audit.Resource{Type: "environment", ID: deletedID},
+		TeamID:    teamID,
+		Metadata:  map[string]string{"name": name},
+	}); err != nil {
+		return fmt.Errorf("emitting audit event: %w", err)
 	}
-	if rows == 0 {
-		return fmt.Errorf("environment %q not found", name)
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing environment delete: %w", err)
 	}
 
 	return nil
+}
+
+// EmitReveal records that an operator viewed raw values of an environment.
+// Callers MUST invoke this before printing sensitive values so that reveals
+// are captured in the audit log. Opens its own short-lived transaction.
+func (s *Store) EmitReveal(ctx context.Context, e *Environment) error {
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("starting audit transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if err := audit.EmitTx(ctx, tx, audit.Event{
+		Timestamp: time.Now(),
+		Actor:     s.actor(),
+		Action:    audit.ActionEnvironmentRevealed,
+		Resource:  audit.Resource{Type: "environment", ID: e.ID},
+		TeamID:    auth.TeamIDFromContext(ctx),
+		Metadata:  map[string]string{"name": e.Name},
+	}); err != nil {
+		return fmt.Errorf("emitting reveal audit event: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing reveal audit event: %w", err)
+	}
+	return nil
+}
+
+func validateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("environment name is required")
+	}
+	if !validEnvNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid environment name %q: must match %s", name, validEnvNamePattern.String())
+	}
+	return nil
+}
+
+func marshalPayload(inputs map[string]any, env map[string]string) ([]byte, []byte, error) {
+	inputsJSON, err := json.Marshal(inputs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshaling inputs: %w", err)
+	}
+	envJSON, err := json.Marshal(env)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshaling env: %w", err)
+	}
+	return inputsJSON, envJSON, nil
 }

--- a/packages/engine/internal/environment/store.go
+++ b/packages/engine/internal/environment/store.go
@@ -264,6 +264,9 @@ func (s *Store) Delete(ctx context.Context, name string) error {
 // Callers MUST invoke this before printing sensitive values so that reveals
 // are captured in the audit log. Opens its own short-lived transaction.
 func (s *Store) EmitReveal(ctx context.Context, e *Environment) error {
+	if e == nil {
+		return fmt.Errorf("cannot emit reveal audit event: environment is nil")
+	}
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("starting audit transaction: %w", err)

--- a/packages/engine/internal/environment/store_test.go
+++ b/packages/engine/internal/environment/store_test.go
@@ -192,8 +192,113 @@ func TestStore_InvalidName(t *testing.T) {
 	store := &Store{DB: setupTestDB(t)}
 	ctx := context.Background()
 
-	_, err := store.Create(ctx, "Invalid Name!", nil, nil)
+	// Space, uppercase, symbols — still rejected.
+	for _, bad := range []string{"", "Invalid Name!", "has space", "UPPER", "-leading", "_trailing_"} {
+		_, err := store.Create(ctx, bad, nil, nil)
+		if err == nil {
+			t.Errorf("expected error for invalid name %q", bad)
+		}
+	}
+}
+
+func TestStore_ValidNameRelaxed(t *testing.T) {
+	store := &Store{DB: setupTestDB(t)}
+	ctx := context.Background()
+
+	// Relaxed regex allows digits first, underscores, hyphens.
+	for _, good := range []string{"prod_1", "env-v2", "123env", "a"} {
+		if _, err := store.Create(ctx, good, nil, nil); err != nil {
+			t.Errorf("expected %q to be valid, got error: %v", good, err)
+		}
+	}
+}
+
+func TestStore_Update(t *testing.T) {
+	database := setupTestDB(t)
+	store := &Store{DB: database}
+	ctx := context.Background()
+
+	created, err := store.Create(ctx, "staging", map[string]any{"url": "old"}, map[string]string{"K": "v1"})
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond) // ensure updated_at moves
+	updated, err := store.Update(ctx, "staging", map[string]any{"url": "new"}, map[string]string{"K": "v2", "NEW": "x"})
+	if err != nil {
+		t.Fatalf("Update() error: %v", err)
+	}
+	if updated.ID != created.ID {
+		t.Errorf("Update() changed ID: %q -> %q", created.ID, updated.ID)
+	}
+	if !updated.CreatedAt.Equal(created.CreatedAt) {
+		t.Errorf("Update() changed CreatedAt: %v -> %v", created.CreatedAt, updated.CreatedAt)
+	}
+	if !updated.UpdatedAt.After(created.UpdatedAt) {
+		t.Errorf("Update() did not advance UpdatedAt: %v vs %v", updated.UpdatedAt, created.UpdatedAt)
+	}
+
+	got, err := store.Get(ctx, "staging")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if got.Inputs["url"] != "new" {
+		t.Errorf("Get() inputs[url] = %v, want %q", got.Inputs["url"], "new")
+	}
+	if got.Env["K"] != "v2" || got.Env["NEW"] != "x" {
+		t.Errorf("Get() env = %v, want K=v2 NEW=x", got.Env)
+	}
+}
+
+func TestStore_UpdateNotFound(t *testing.T) {
+	store := &Store{DB: setupTestDB(t)}
+	ctx := context.Background()
+
+	_, err := store.Update(ctx, "missing", nil, nil)
 	if err == nil {
-		t.Fatal("expected error for invalid name")
+		t.Fatal("Update() expected error for missing environment")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("Update() error = %q, want to contain 'not found'", err.Error())
+	}
+}
+
+func TestStore_AuditEvents(t *testing.T) {
+	database := setupTestDB(t)
+	store := &Store{DB: database}
+	ctx := context.Background()
+
+	created, err := store.Create(ctx, "audited", map[string]any{"k": "v"}, nil)
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+	if _, err := store.Update(ctx, "audited", map[string]any{"k": "v2"}, nil); err != nil {
+		t.Fatalf("Update() error: %v", err)
+	}
+	if err := store.EmitReveal(ctx, created); err != nil {
+		t.Fatalf("EmitReveal() error: %v", err)
+	}
+	if err := store.Delete(ctx, "audited"); err != nil {
+		t.Fatalf("Delete() error: %v", err)
+	}
+
+	want := map[string]int{
+		"environment.created":  1,
+		"environment.updated":  1,
+		"environment.revealed": 1,
+		"environment.deleted":  1,
+	}
+	for action, n := range want {
+		var count int
+		row := database.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM audit_events WHERE action = $1 AND resource_type = 'environment' AND resource_id = $2`,
+			action, created.ID,
+		)
+		if err := row.Scan(&count); err != nil {
+			t.Fatalf("query audit count for %s: %v", action, err)
+		}
+		if count != n {
+			t.Errorf("audit events for %s = %d, want %d", action, count, n)
+		}
 	}
 }

--- a/packages/engine/internal/environment/store_test.go
+++ b/packages/engine/internal/environment/store_test.go
@@ -199,6 +199,16 @@ func TestStore_InvalidName(t *testing.T) {
 			t.Errorf("expected error for invalid name %q", bad)
 		}
 	}
+
+	// Length cap: exactly 63 chars is allowed, 64 is rejected.
+	longOK := strings.Repeat("a", 63)
+	if _, err := store.Create(ctx, longOK, nil, nil); err != nil {
+		t.Errorf("expected 63-char name to be accepted, got error: %v", err)
+	}
+	tooLong := strings.Repeat("a", 64)
+	if _, err := store.Create(ctx, tooLong, nil, nil); err == nil {
+		t.Errorf("expected 64-char name to be rejected")
+	}
 }
 
 func TestStore_ValidNameRelaxed(t *testing.T) {
@@ -223,7 +233,6 @@ func TestStore_Update(t *testing.T) {
 		t.Fatalf("Create() error: %v", err)
 	}
 
-	time.Sleep(10 * time.Millisecond) // ensure updated_at moves
 	updated, err := store.Update(ctx, "staging", map[string]any{"url": "new"}, map[string]string{"K": "v2", "NEW": "x"})
 	if err != nil {
 		t.Fatalf("Update() error: %v", err)
@@ -234,8 +243,11 @@ func TestStore_Update(t *testing.T) {
 	if !updated.CreatedAt.Equal(created.CreatedAt) {
 		t.Errorf("Update() changed CreatedAt: %v -> %v", created.CreatedAt, updated.CreatedAt)
 	}
-	if !updated.UpdatedAt.After(created.UpdatedAt) {
-		t.Errorf("Update() did not advance UpdatedAt: %v vs %v", updated.UpdatedAt, created.UpdatedAt)
+	// Assert non-decreasing rather than strictly after: Postgres NOW() can
+	// return the same value for two quickly-successive transactions on some
+	// systems. Strict inequality made this test wall-clock dependent.
+	if updated.UpdatedAt.Before(created.UpdatedAt) {
+		t.Errorf("Update() moved UpdatedAt backwards: created=%v updated=%v", created.UpdatedAt, updated.UpdatedAt)
 	}
 
 	got, err := store.Get(ctx, "staging")

--- a/packages/engine/internal/environment/store_test.go
+++ b/packages/engine/internal/environment/store_test.go
@@ -275,6 +275,19 @@ func TestStore_UpdateNotFound(t *testing.T) {
 	}
 }
 
+func TestStore_EmitRevealNil(t *testing.T) {
+	store := &Store{DB: setupTestDB(t)}
+	ctx := context.Background()
+
+	err := store.EmitReveal(ctx, nil)
+	if err == nil {
+		t.Fatal("EmitReveal(nil) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "nil") {
+		t.Errorf("EmitReveal(nil) error = %q, want to mention 'nil'", err.Error())
+	}
+}
+
 func TestStore_AuditEvents(t *testing.T) {
 	database := setupTestDB(t)
 	store := &Store{DB: database}

--- a/packages/engine/internal/workflow/values.go
+++ b/packages/engine/internal/workflow/values.go
@@ -63,35 +63,73 @@ func LoadValuesBytes(data []byte) (*Values, error) {
 	return &vals, nil
 }
 
+// Source identifies which override layer supplied a resolved value.
+type Source string
+
+const (
+	SourceDefault Source = "default"
+	SourceEnv     Source = "env"
+	SourceValues  Source = "values"
+	SourceInline  Source = "inline"
+)
+
+// Resolved pairs a final merged value with the layer it originated from.
+type Resolved struct {
+	Value  any
+	Source Source
+}
+
 // MergeInputs combines input values with the following precedence (highest wins):
 //
 //	inline --input flags > values file inputs > named environment inputs > workflow definition defaults
 //
 // All layers are optional (nil-safe).
 func MergeInputs(workflowInputs map[string]Input, envInputs map[string]any, valuesInputs map[string]any, inlineInputs map[string]any) map[string]any {
-	result := make(map[string]any)
+	merged := ResolveInputs(workflowInputs, envInputs, valuesInputs, inlineInputs)
+	result := make(map[string]any, len(merged))
+	for k, v := range merged {
+		result[k] = v.Value
+	}
+	return result
+}
 
-	// Layer 1: workflow definition defaults (lowest precedence).
+// ResolveInputs is like MergeInputs but preserves which layer each final value
+// came from. Callers that need to display "where did this value come from?"
+// (e.g., `mantle plan --env`) should use this.
+func ResolveInputs(workflowInputs map[string]Input, envInputs map[string]any, valuesInputs map[string]any, inlineInputs map[string]any) map[string]Resolved {
+	result := make(map[string]Resolved)
+
 	for name, input := range workflowInputs {
 		if input.Default != nil {
-			result[name] = input.Default
+			result[name] = Resolved{Value: input.Default, Source: SourceDefault}
 		}
 	}
-
-	// Layer 2: named environment inputs.
 	for k, v := range envInputs {
-		result[k] = v
+		result[k] = Resolved{Value: v, Source: SourceEnv}
 	}
-
-	// Layer 3: values file inputs.
 	for k, v := range valuesInputs {
-		result[k] = v
+		result[k] = Resolved{Value: v, Source: SourceValues}
 	}
-
-	// Layer 4: inline --input flags (highest precedence).
 	for k, v := range inlineInputs {
-		result[k] = v
+		result[k] = Resolved{Value: v, Source: SourceInline}
 	}
 
+	return result
+}
+
+// ResolveEnvVars merges env-var layers (config < named env < values file) and
+// records the source of each final value. MANTLE_ENV_* OS variables are not
+// resolved here because plan runs before execution and OS env can change.
+func ResolveEnvVars(configEnv map[string]string, envEnv map[string]string, valuesEnv map[string]string) map[string]Resolved {
+	result := make(map[string]Resolved)
+	for k, v := range configEnv {
+		result[k] = Resolved{Value: v, Source: "config"}
+	}
+	for k, v := range envEnv {
+		result[k] = Resolved{Value: v, Source: SourceEnv}
+	}
+	for k, v := range valuesEnv {
+		result[k] = Resolved{Value: v, Source: SourceValues}
+	}
 	return result
 }

--- a/packages/engine/internal/workflow/values.go
+++ b/packages/engine/internal/workflow/values.go
@@ -68,6 +68,7 @@ type Source string
 
 const (
 	SourceDefault Source = "default"
+	SourceConfig  Source = "config"
 	SourceEnv     Source = "env"
 	SourceValues  Source = "values"
 	SourceInline  Source = "inline"
@@ -123,7 +124,7 @@ func ResolveInputs(workflowInputs map[string]Input, envInputs map[string]any, va
 func ResolveEnvVars(configEnv map[string]string, envEnv map[string]string, valuesEnv map[string]string) map[string]Resolved {
 	result := make(map[string]Resolved)
 	for k, v := range configEnv {
-		result[k] = Resolved{Value: v, Source: "config"}
+		result[k] = Resolved{Value: v, Source: SourceConfig}
 	}
 	for k, v := range envEnv {
 		result[k] = Resolved{Value: v, Source: SourceEnv}


### PR DESCRIPTION
## Summary

Follow-up fixes on top of merged PR [#127](https://github.com/dvflw/mantle/pull/127) (issue [#53](https://github.com/dvflw/mantle/issues/53)) based on a pre-push review pass with Technical Writer, Product Manager, Legal Compliance, and Reality Checker agents. The original env-values feature shipped with two policy violations and several user-experience blockers that this PR addresses.

### Secret hygiene — CLAUDE.md opaque-handle policy
- `mantle env get` redacts every env value by default and tells the user how to unredact.
- `--reveal` prints raw values and emits an `environment.revealed` audit event so every disclosure is logged.
- Before this change, values like `GITHUB_TOKEN=ghp_…` in a values file would be echoed to stdout and terminal scrollback on any `env show`.

### Audit coverage — CLAUDE.md "every state-changing op emits an audit event" policy
- New actions: `environment.{created,updated,deleted,revealed}`.
- `Store.Create` / `Update` / `Delete` now open a tx, write, and emit the audit event atomically.
- `Store` gains an `Actor` field (defaults to `"cli"`) so future server / scheduler callers can attribute correctly.

### User-visible gaps
- `mantle env update <name> --from file.yaml` replaces inputs and env while preserving id, `created_at`, and audit history. Previously operators had to `delete` + `create`, silently losing id + audit lineage.
- `mantle plan --env <name>` (and `--values`) now appends a **Resolved configuration** block showing each final input and env var with the layer it came from (`default` / `env` / `values`). Previously `--env` on plan only validated existence — a footgun PM flagged as promotion-unsafe.
- `mantle env delete <name>` requires `--yes` / `-y`. One typo no longer destroys `production`.
- `mantle env get <name>` shows `ID`, `Created`, and `Updated` timestamps in UTC so operators can answer "why did last night's run behave differently?"
- `env show` renamed to `env get` to match `kubectl`/`gh` conventions.
- Name regex relaxed from `^[a-z][a-z0-9-]*$` to `^[a-z0-9][a-z0-9_-]*$`. `prod_1`, `env-v2`, and `123env` now validate; Terraform/Helm/K8s workspace conventions line up.

### Polish
- Migration `018_environments.sql` gains a header comment explaining purpose and the reveal contract.
- `cel.SetValuesEnv` godoc clarifies that both values files and named environments feed the same layer.
- `environment` package switches `err == sql.ErrNoRows` to `errors.Is`, exports an `ErrNotFound` sentinel.
- CLI help text gains `Long` and `Example` across every env subcommand; the root `env` Long describes the override precedence chain.
- `CLAUDE.md` Key Commands lists `mantle env *` and `--values` / `--env` with the full precedence chain.

## Test plan
- [x] `go build ./...` from `packages/engine` — clean
- [x] `go test ./internal/environment/... ./internal/cli/... ./internal/workflow/... ./internal/cel/...` — green
- [x] New tests: `TestStore_Update`, `TestStore_UpdateNotFound`, `TestStore_AuditEvents`, `TestStore_ValidNameRelaxed`, broader `TestStore_InvalidName`, `TestWriteResolvedOverrides_*`
- [ ] Manual CLI smoke on a real deployment: `env create` → `env get` (redacted) → `env get --reveal` (audited) → `env update` → `env list` → `plan --env` shows Resolved configuration → `env delete` without `--yes` refuses → `env delete --yes` succeeds

Closes remaining gaps flagged against [#53](https://github.com/dvflw/mantle/issues/53) during pre-release review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Named environments: create, update, list (now shows UPDATED), get (prints Name/ID/Created/Updated; values redacted by default, optional --reveal), and delete (requires -y/--yes).
  * run/plan accept --values and --env; plan appends a resolved-configuration block showing per-key sources and override precedence.
  * Audit events recorded for environment create/update/delete/reveal.

* **Documentation**
  * CLI docs updated for new env subcommands, --values/--env behavior, and explicit override precedence.

* **Tests**
  * Added tests for resolved output rendering and environment lifecycle/audit behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->