### PR TITLE
feat: git sync foundation (Plan A of issue #16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,8 @@ git_sync:
 
 Credentials of type `git` accept `token` (for HTTPS), `ssh_key` (for SSH), and optional `username`. At least one of `token` or `ssh_key` is required.
 
+> Plan A ships the repo registry and CLI only. The sync engine that consumes this block — pulling from the sidecar, validating, and applying workflow YAML — ships in the next milestone. Registering a repo today has no runtime effect yet beyond persistence.
+
 ## License
 
 BSL/SSPL-style — source available, no commercial resale of forks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,10 @@ mantle env update <name>      # Replace inputs/env on an existing environment
 mantle env list               # List named environments
 mantle env get <name>         # Show environment details (env values redacted; --reveal to unredact, audited)
 mantle env delete <name> -y   # Delete a named environment (requires --yes)
+mantle repos add <name> --url <url> --credential <cred>  # Register a GitOps source repo
+mantle repos list              # List registered repos with last-sync status
+mantle repos status <name>     # Show detailed repo status
+mantle repos remove <name> -y  # Unregister a repo (requires --yes)
 mantle run <wf> --values f.yaml   # Run with a values file (inputs + env overrides)
 mantle run <wf> --env <name>      # Run against a stored named environment
 mantle plan <wf> --env <name>     # Plan; appends resolved inputs/env with source
@@ -90,6 +94,25 @@ mantle serve                  # Start persistent server
 
 - **Workflow inputs** (consumed by `inputs.<name>` in CEL): `--input` flags > `--values` file `inputs:` > `--env` named-environment `inputs` > workflow definition `default`
 - **Env vars** (consumed by `env.<KEY>` in CEL): `MANTLE_ENV_*` OS vars > `--values` file `env:` > `--env` named-environment `env` > config `env:` section in `mantle.yaml`
+
+## GitOps Config
+
+Register repos in `mantle.yaml` under `git_sync.repos`:
+
+```yaml
+git_sync:
+  repos:
+    - name: acme
+      url: https://github.com/acme/workflows.git
+      branch: main
+      path: /
+      poll_interval: 60s
+      credential: github-pat   # must reference a secret of type: git
+      auto_apply: true
+      prune: true
+```
+
+Credentials of type `git` accept `token` (for HTTPS), `ssh_key` (for SSH), and optional `username`. At least one of `token` or `ssh_key` is required.
 
 ## License
 

--- a/packages/engine/internal/audit/audit.go
+++ b/packages/engine/internal/audit/audit.go
@@ -61,6 +61,11 @@ const (
 	ActionEnvironmentUpdated  Action = "environment.updated"
 	ActionEnvironmentDeleted  Action = "environment.deleted"
 	ActionEnvironmentRevealed Action = "environment.revealed"
+
+	// Git repo operations.
+	ActionRepoAdded   Action = "repo.added"
+	ActionRepoUpdated Action = "repo.updated"
+	ActionRepoRemoved Action = "repo.removed"
 )
 
 // Resource identifies the target of an audit event.

--- a/packages/engine/internal/audit/audit.go
+++ b/packages/engine/internal/audit/audit.go
@@ -63,9 +63,9 @@ const (
 	ActionEnvironmentRevealed Action = "environment.revealed"
 
 	// Git repo operations.
-	ActionRepoAdded   Action = "repo.added"
+	ActionRepoAdded   Action = "repo.created"
 	ActionRepoUpdated Action = "repo.updated"
-	ActionRepoRemoved Action = "repo.removed"
+	ActionRepoRemoved Action = "repo.deleted"
 )
 
 // Resource identifies the target of an audit event.

--- a/packages/engine/internal/cli/repos.go
+++ b/packages/engine/internal/cli/repos.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"text/tabwriter"
 
 	"github.com/dvflw/mantle/internal/config"
 	"github.com/dvflw/mantle/internal/db"
@@ -23,6 +24,7 @@ Auth material is stored in a "git" credential type (` + "`mantle secrets create 
 and referenced here by name.`,
 	}
 	cmd.AddCommand(newReposAddCommand())
+	cmd.AddCommand(newReposListCommand())
 	return cmd
 }
 
@@ -89,4 +91,39 @@ credential must already exist and be of type "git".`,
 	_ = cmd.MarkFlagRequired("credential")
 
 	return cmd
+}
+
+func newReposListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all registered GitOps repos",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, cleanup, err := newRepoStore(cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			repos, err := store.List(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if len(repos) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "(no repos)")
+				return nil
+			}
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "NAME\tURL\tBRANCH\tAUTO-APPLY\tENABLED\tLAST SYNC")
+			for _, r := range repos {
+				last := "(never)"
+				if r.LastSyncAt != nil {
+					last = r.LastSyncAt.UTC().Format("2006-01-02 15:04:05 UTC")
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%t\t%t\t%s\n",
+					r.Name, r.URL, r.Branch, r.AutoApply, r.Enabled, last)
+			}
+			return w.Flush()
+		},
+	}
 }

--- a/packages/engine/internal/cli/repos.go
+++ b/packages/engine/internal/cli/repos.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/dvflw/mantle/internal/config"
+	"github.com/dvflw/mantle/internal/db"
+	"github.com/dvflw/mantle/internal/repo"
+	"github.com/spf13/cobra"
+)
+
+// newReposCommand returns the "repos" subcommand for managing registered
+// GitOps source repositories (issue #16). Subcommands handle registration,
+// listing, detailed status, and removal. Sync behavior lives in Plan B.
+func newReposCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repos",
+		Short: "Manage GitOps workflow source repositories",
+		Long: `Registered repos are periodically pulled by the git-sync sidecar and
+their .yaml workflow definitions are applied to this Mantle instance.
+
+Auth material is stored in a "git" credential type (` + "`mantle secrets create --type git`" + `)
+and referenced here by name.`,
+	}
+	return cmd
+}
+
+// newRepoStore builds a repo.Store from the current command context.
+func newRepoStore(cmd *cobra.Command) (*repo.Store, func(), error) {
+	cfg := config.FromContext(cmd.Context())
+	if cfg == nil {
+		return nil, nil, fmt.Errorf("config not loaded")
+	}
+	database, err := db.Open(cfg.Database)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to database: %w", err)
+	}
+	store := &repo.Store{DB: database, Actor: "cli"}
+	cleanup := func() { database.Close() }
+	return store, cleanup, nil
+}

--- a/packages/engine/internal/cli/repos.go
+++ b/packages/engine/internal/cli/repos.go
@@ -25,6 +25,7 @@ and referenced here by name.`,
 	}
 	cmd.AddCommand(newReposAddCommand())
 	cmd.AddCommand(newReposListCommand())
+	cmd.AddCommand(newReposStatusCommand())
 	return cmd
 }
 
@@ -91,6 +92,47 @@ credential must already exist and be of type "git".`,
 	_ = cmd.MarkFlagRequired("credential")
 
 	return cmd
+}
+
+func newReposStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status <name>",
+		Short: "Show detailed status for a registered repo",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, cleanup, err := newRepoStore(cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			r, err := store.Get(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Name:         %s\n", r.Name)
+			fmt.Fprintf(out, "ID:           %s\n", r.ID)
+			fmt.Fprintf(out, "URL:          %s\n", r.URL)
+			fmt.Fprintf(out, "Branch:       %s\n", r.Branch)
+			fmt.Fprintf(out, "Path:         %s\n", r.Path)
+			fmt.Fprintf(out, "Poll:         %s\n", r.PollInterval)
+			fmt.Fprintf(out, "Credential:   %s\n", r.Credential)
+			fmt.Fprintf(out, "Auto-Apply:   %t\n", r.AutoApply)
+			fmt.Fprintf(out, "Prune:        %t\n", r.Prune)
+			fmt.Fprintf(out, "Enabled:      %t\n", r.Enabled)
+			if r.LastSyncAt != nil {
+				fmt.Fprintf(out, "Last Sync:    %s (SHA %s)\n",
+					r.LastSyncAt.UTC().Format("2006-01-02 15:04:05 UTC"), r.LastSyncSHA)
+			} else {
+				fmt.Fprintln(out, "Last Sync:    (never)")
+			}
+			if r.LastSyncError != "" {
+				fmt.Fprintf(out, "Last Error:   %s\n", r.LastSyncError)
+			}
+			return nil
+		},
+	}
 }
 
 func newReposListCommand() *cobra.Command {

--- a/packages/engine/internal/cli/repos.go
+++ b/packages/engine/internal/cli/repos.go
@@ -22,6 +22,7 @@ their .yaml workflow definitions are applied to this Mantle instance.
 Auth material is stored in a "git" credential type (` + "`mantle secrets create --type git`" + `)
 and referenced here by name.`,
 	}
+	cmd.AddCommand(newReposAddCommand())
 	return cmd
 }
 
@@ -38,4 +39,54 @@ func newRepoStore(cmd *cobra.Command) (*repo.Store, func(), error) {
 	store := &repo.Store{DB: database, Actor: "cli"}
 	cleanup := func() { database.Close() }
 	return store, cleanup, nil
+}
+
+func newReposAddCommand() *cobra.Command {
+	var url, branch, path, pollInterval, credential string
+	var autoApply, prune bool
+
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Register a new GitOps source repo",
+		Long: `Registers a new repository to sync workflow definitions from. The named
+credential must already exist and be of type "git".`,
+		Example: `  mantle repos add acme --url https://github.com/acme/workflows.git --credential github-pat
+  mantle repos add staging --url git@github.com:acme/wf.git --credential github-ssh --branch release`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, cleanup, err := newRepoStore(cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			r, err := store.Create(cmd.Context(), repo.CreateParams{
+				Name:         args[0],
+				URL:          url,
+				Branch:       branch,
+				Path:         path,
+				PollInterval: pollInterval,
+				Credential:   credential,
+				AutoApply:    autoApply,
+				Prune:        prune,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Added repo %q (%s)\n", r.Name, r.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&url, "url", "", "Git repository URL (required)")
+	cmd.Flags().StringVar(&branch, "branch", "main", "Branch to sync")
+	cmd.Flags().StringVar(&path, "path", "/", "Subdirectory inside the repo to scan")
+	cmd.Flags().StringVar(&pollInterval, "poll-interval", "60s", "Interval between syncs (Go duration, min 10s)")
+	cmd.Flags().StringVar(&credential, "credential", "", "Git credential name (required)")
+	cmd.Flags().BoolVar(&autoApply, "auto-apply", true, "Automatically apply changes (false = plan-only)")
+	cmd.Flags().BoolVar(&prune, "prune", true, "Disable workflows removed from the repo")
+	_ = cmd.MarkFlagRequired("url")
+	_ = cmd.MarkFlagRequired("credential")
+
+	return cmd
 }

--- a/packages/engine/internal/cli/repos.go
+++ b/packages/engine/internal/cli/repos.go
@@ -26,6 +26,7 @@ and referenced here by name.`,
 	cmd.AddCommand(newReposAddCommand())
 	cmd.AddCommand(newReposListCommand())
 	cmd.AddCommand(newReposStatusCommand())
+	cmd.AddCommand(newReposRemoveCommand())
 	return cmd
 }
 
@@ -133,6 +134,35 @@ func newReposStatusCommand() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func newReposRemoveCommand() *cobra.Command {
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "remove <name>",
+		Short: "Unregister a GitOps source repo",
+		Long: `Unregisters a repo. Any previously applied workflows remain in place — this
+command only stops future syncs. Requires --yes to confirm.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !yes {
+				return fmt.Errorf("refusing to remove %q without --yes", args[0])
+			}
+			store, cleanup, err := newRepoStore(cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			if err := store.Delete(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Removed repo %q\n", args[0])
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Confirm deletion (required)")
+	return cmd
 }
 
 func newReposListCommand() *cobra.Command {

--- a/packages/engine/internal/cli/repos.go
+++ b/packages/engine/internal/cli/repos.go
@@ -17,11 +17,11 @@ func newReposCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "repos",
 		Short: "Manage GitOps workflow source repositories",
-		Long: `Registered repos are periodically pulled by the git-sync sidecar and
-their .yaml workflow definitions are applied to this Mantle instance.
-
-Auth material is stored in a "git" credential type (` + "`mantle secrets create --type git`" + `)
-and referenced here by name.`,
+		Long: `Registers GitOps source repositories whose workflow YAML definitions will be
+synced into this Mantle instance. This command manages the registry; the sync
+engine itself (sidecar, file discovery, validate/plan/apply) ships in a later
+milestone. Auth material is stored in a "git" credential type
+(` + "`mantle secrets create --type git`" + `) and referenced here by name.`,
 	}
 	cmd.AddCommand(newReposAddCommand())
 	cmd.AddCommand(newReposListCommand())
@@ -88,7 +88,7 @@ credential must already exist and be of type "git".`,
 	cmd.Flags().StringVar(&pollInterval, "poll-interval", "60s", "Interval between syncs (Go duration, min 10s)")
 	cmd.Flags().StringVar(&credential, "credential", "", "Git credential name (required)")
 	cmd.Flags().BoolVar(&autoApply, "auto-apply", true, "Automatically apply changes (false = plan-only)")
-	cmd.Flags().BoolVar(&prune, "prune", true, "Disable workflows removed from the repo")
+	cmd.Flags().BoolVar(&prune, "prune", true, "When true, workflows deleted from the repo are disabled in Mantle")
 	_ = cmd.MarkFlagRequired("url")
 	_ = cmd.MarkFlagRequired("credential")
 

--- a/packages/engine/internal/cli/repos.go
+++ b/packages/engine/internal/cli/repos.go
@@ -99,7 +99,12 @@ func newReposStatusCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status <name>",
 		Short: "Show detailed status for a registered repo",
-		Args:  cobra.ExactArgs(1),
+		Long: `Displays all persisted fields for a registered repository, including the
+URL, branch, polling interval, credential reference, enable state, and the
+outcome of the most recent sync attempt (SHA, timestamp, and any error).`,
+		Example: `  mantle repos status acme
+  mantle repos status staging --database-url postgres://localhost/mantle`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store, cleanup, err := newRepoStore(cmd)
 			if err != nil {
@@ -169,7 +174,12 @@ func newReposListCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List all registered GitOps repos",
-		Args:  cobra.NoArgs,
+		Long: `Prints a table of all repositories registered for the current team, ordered
+by name. Columns include the repo URL, target branch, auto-apply flag, enable
+state, and timestamp of the last successful sync.`,
+		Example: `  mantle repos list
+  mantle repos list --database-url postgres://localhost/mantle`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store, cleanup, err := newRepoStore(cmd)
 			if err != nil {

--- a/packages/engine/internal/cli/repos_test.go
+++ b/packages/engine/internal/cli/repos_test.go
@@ -151,3 +151,56 @@ func TestReposStatus_ShowsDetails(t *testing.T) {
 		}
 	}
 }
+
+func TestReposRemove_RequiresYesFlag(t *testing.T) {
+	_, cfg := reposCtx(t)
+	{
+		root := NewRootCommand()
+		var seedStderr bytes.Buffer
+		root.SetErr(&seedStderr)
+		root.SetArgs([]string{"repos", "add", "acme",
+			"--url", "https://example.com/a.git",
+			"--credential", "pat",
+			"--database-url", cfg.Database.URL,
+		})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("seed add: %v\nstderr: %s", err, seedStderr.String())
+		}
+	}
+	root := NewRootCommand()
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"repos", "remove", "acme", "--database-url", cfg.Database.URL})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("expected --yes error, got %v", err)
+	}
+}
+
+func TestReposRemove_DeletesRow(t *testing.T) {
+	_, cfg := reposCtx(t)
+	{
+		root := NewRootCommand()
+		var seedStderr bytes.Buffer
+		root.SetErr(&seedStderr)
+		root.SetArgs([]string{"repos", "add", "acme",
+			"--url", "https://example.com/a.git",
+			"--credential", "pat",
+			"--database-url", cfg.Database.URL,
+		})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("seed add: %v\nstderr: %s", err, seedStderr.String())
+		}
+	}
+	root := NewRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"repos", "remove", "acme", "--yes", "--database-url", cfg.Database.URL})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("remove: %v\nstderr: %s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Removed repo \"acme\"") {
+		t.Errorf("unexpected stdout: %q", stdout.String())
+	}
+}

--- a/packages/engine/internal/cli/repos_test.go
+++ b/packages/engine/internal/cli/repos_test.go
@@ -75,3 +75,48 @@ func TestReposAdd_PersistsRepo(t *testing.T) {
 		t.Errorf("unexpected stdout: %q", stdout.String())
 	}
 }
+
+func TestReposList_ShowsRegisteredRepos(t *testing.T) {
+	_, cfg := reposCtx(t)
+	// Seed one row by calling the add command.
+	{
+		root := NewRootCommand()
+		var seedStderr bytes.Buffer
+		root.SetErr(&seedStderr)
+		root.SetArgs([]string{"repos", "add", "acme",
+			"--url", "https://example.com/a.git",
+			"--credential", "pat",
+			"--database-url", cfg.Database.URL,
+		})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("seed add: %v\nstderr: %s", err, seedStderr.String())
+		}
+	}
+	root := NewRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"repos", "list", "--database-url", cfg.Database.URL})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("list: %v\nstderr: %s", err, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "acme") || !strings.Contains(out, "NAME") {
+		t.Errorf("list output missing expected fields: %q", out)
+	}
+}
+
+func TestReposList_EmptyState(t *testing.T) {
+	_, cfg := reposCtx(t)
+	root := NewRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"repos", "list", "--database-url", cfg.Database.URL})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("list: %v\nstderr: %s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "(no repos)") {
+		t.Errorf("empty list output: %q", stdout.String())
+	}
+}

--- a/packages/engine/internal/cli/repos_test.go
+++ b/packages/engine/internal/cli/repos_test.go
@@ -120,3 +120,34 @@ func TestReposList_EmptyState(t *testing.T) {
 		t.Errorf("empty list output: %q", stdout.String())
 	}
 }
+
+func TestReposStatus_ShowsDetails(t *testing.T) {
+	_, cfg := reposCtx(t)
+	{
+		root := NewRootCommand()
+		var seedStderr bytes.Buffer
+		root.SetErr(&seedStderr)
+		root.SetArgs([]string{"repos", "add", "acme",
+			"--url", "https://example.com/a.git",
+			"--credential", "pat",
+			"--database-url", cfg.Database.URL,
+		})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("seed add: %v\nstderr: %s", err, seedStderr.String())
+		}
+	}
+	root := NewRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"repos", "status", "acme", "--database-url", cfg.Database.URL})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("status: %v\nstderr: %s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"Name:", "URL:", "Branch:", "Credential:", "Auto-Apply:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("status output missing %q: %s", want, out)
+		}
+	}
+}

--- a/packages/engine/internal/cli/repos_test.go
+++ b/packages/engine/internal/cli/repos_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dvflw/mantle/internal/config"
+	"github.com/dvflw/mantle/internal/db"
+	"github.com/dvflw/mantle/internal/dbdefaults"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// reposCtx spins up a Postgres container, runs migrations, and returns a
+// context with the DatabaseConfig attached so `newRepoStore` can load it.
+func reposCtx(t *testing.T) (context.Context, *config.Config) {
+	t.Helper()
+	bg := context.Background()
+	pgContainer, err := postgres.Run(bg,
+		dbdefaults.PostgresImage,
+		postgres.WithDatabase(dbdefaults.TestDatabase),
+		postgres.WithUsername(dbdefaults.User),
+		postgres.WithPassword(dbdefaults.Password),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+	)
+	if err != nil {
+		if os.Getenv("CI") != "" {
+			t.Fatalf("Postgres (CI): %v", err)
+		}
+		t.Skipf("Postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = pgContainer.Terminate(bg) })
+	connStr, err := pgContainer.ConnectionString(bg, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("ConnectionString: %v", err)
+	}
+	dbCfg := config.DatabaseConfig{URL: connStr}
+	conn, err := db.Open(dbCfg)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	if err := db.Migrate(bg, conn); err != nil {
+		t.Fatalf("db.Migrate: %v", err)
+	}
+	cfg := &config.Config{Database: dbCfg}
+	ctx := config.WithContext(bg, cfg)
+	return ctx, cfg
+}
+
+func TestReposAdd_PersistsRepo(t *testing.T) {
+	_, cfg := reposCtx(t)
+	root := NewRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"repos", "add", "acme",
+		"--url", "https://github.com/acme/workflows.git",
+		"--credential", "github-pat",
+		"--database-url", cfg.Database.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v\nstderr: %s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Added repo \"acme\"") {
+		t.Errorf("unexpected stdout: %q", stdout.String())
+	}
+}

--- a/packages/engine/internal/cli/repos_test.go
+++ b/packages/engine/internal/cli/repos_test.go
@@ -57,6 +57,23 @@ func reposCtx(t *testing.T) (context.Context, *config.Config) {
 	return ctx, cfg
 }
 
+// seedRepo registers a single repo via the add command, failing the test on
+// error. Shared by tests that need at least one row in git_repos.
+func seedRepo(t *testing.T, cfg *config.Config, name string) {
+	t.Helper()
+	root := NewRootCommand()
+	var seedStderr bytes.Buffer
+	root.SetErr(&seedStderr)
+	root.SetArgs([]string{"repos", "add", name,
+		"--url", "https://example.com/a.git",
+		"--credential", "pat",
+		"--database-url", cfg.Database.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("seedRepo(%q): %v\nstderr: %s", name, err, seedStderr.String())
+	}
+}
+
 func TestReposAdd_PersistsRepo(t *testing.T) {
 	_, cfg := reposCtx(t)
 	root := NewRootCommand()
@@ -78,20 +95,8 @@ func TestReposAdd_PersistsRepo(t *testing.T) {
 
 func TestReposList_ShowsRegisteredRepos(t *testing.T) {
 	_, cfg := reposCtx(t)
-	// Seed one row by calling the add command.
-	{
-		root := NewRootCommand()
-		var seedStderr bytes.Buffer
-		root.SetErr(&seedStderr)
-		root.SetArgs([]string{"repos", "add", "acme",
-			"--url", "https://example.com/a.git",
-			"--credential", "pat",
-			"--database-url", cfg.Database.URL,
-		})
-		if err := root.Execute(); err != nil {
-			t.Fatalf("seed add: %v\nstderr: %s", err, seedStderr.String())
-		}
-	}
+	seedRepo(t, cfg, "acme")
+
 	root := NewRootCommand()
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
@@ -116,26 +121,15 @@ func TestReposList_EmptyState(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatalf("list: %v\nstderr: %s", err, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "(no repos)") {
+	if strings.TrimSpace(stdout.String()) != "(no repos)" {
 		t.Errorf("empty list output: %q", stdout.String())
 	}
 }
 
 func TestReposStatus_ShowsDetails(t *testing.T) {
 	_, cfg := reposCtx(t)
-	{
-		root := NewRootCommand()
-		var seedStderr bytes.Buffer
-		root.SetErr(&seedStderr)
-		root.SetArgs([]string{"repos", "add", "acme",
-			"--url", "https://example.com/a.git",
-			"--credential", "pat",
-			"--database-url", cfg.Database.URL,
-		})
-		if err := root.Execute(); err != nil {
-			t.Fatalf("seed add: %v\nstderr: %s", err, seedStderr.String())
-		}
-	}
+	seedRepo(t, cfg, "acme")
+
 	root := NewRootCommand()
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
@@ -154,19 +148,8 @@ func TestReposStatus_ShowsDetails(t *testing.T) {
 
 func TestReposRemove_RequiresYesFlag(t *testing.T) {
 	_, cfg := reposCtx(t)
-	{
-		root := NewRootCommand()
-		var seedStderr bytes.Buffer
-		root.SetErr(&seedStderr)
-		root.SetArgs([]string{"repos", "add", "acme",
-			"--url", "https://example.com/a.git",
-			"--credential", "pat",
-			"--database-url", cfg.Database.URL,
-		})
-		if err := root.Execute(); err != nil {
-			t.Fatalf("seed add: %v\nstderr: %s", err, seedStderr.String())
-		}
-	}
+	seedRepo(t, cfg, "acme")
+
 	root := NewRootCommand()
 	var stderr bytes.Buffer
 	root.SetErr(&stderr)
@@ -179,19 +162,8 @@ func TestReposRemove_RequiresYesFlag(t *testing.T) {
 
 func TestReposRemove_DeletesRow(t *testing.T) {
 	_, cfg := reposCtx(t)
-	{
-		root := NewRootCommand()
-		var seedStderr bytes.Buffer
-		root.SetErr(&seedStderr)
-		root.SetArgs([]string{"repos", "add", "acme",
-			"--url", "https://example.com/a.git",
-			"--credential", "pat",
-			"--database-url", cfg.Database.URL,
-		})
-		if err := root.Execute(); err != nil {
-			t.Fatalf("seed add: %v\nstderr: %s", err, seedStderr.String())
-		}
-	}
+	seedRepo(t, cfg, "acme")
+
 	root := NewRootCommand()
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)

--- a/packages/engine/internal/cli/repos_test.go
+++ b/packages/engine/internal/cli/repos_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"strings"
 	"testing"
@@ -17,10 +16,11 @@ import (
 )
 
 // reposCtx spins up a Postgres container, runs migrations, and returns a
-// context with the DatabaseConfig attached so `newRepoStore` can load it.
-func reposCtx(t *testing.T) (context.Context, *config.Config) {
+// *config.Config with the DatabaseConfig attached. Callers pass the database
+// URL via --database-url flags; the config is used only to read that URL.
+func reposCtx(t *testing.T) *config.Config {
 	t.Helper()
-	bg := context.Background()
+	bg := t.Context()
 	pgContainer, err := postgres.Run(bg,
 		dbdefaults.PostgresImage,
 		postgres.WithDatabase(dbdefaults.TestDatabase),
@@ -52,9 +52,7 @@ func reposCtx(t *testing.T) (context.Context, *config.Config) {
 	if err := db.Migrate(bg, conn); err != nil {
 		t.Fatalf("db.Migrate: %v", err)
 	}
-	cfg := &config.Config{Database: dbCfg}
-	ctx := config.WithContext(bg, cfg)
-	return ctx, cfg
+	return &config.Config{Database: dbCfg}
 }
 
 // seedRepo registers a single repo via the add command, failing the test on
@@ -75,7 +73,7 @@ func seedRepo(t *testing.T, cfg *config.Config, name string) {
 }
 
 func TestReposAdd_PersistsRepo(t *testing.T) {
-	_, cfg := reposCtx(t)
+	cfg := reposCtx(t)
 	root := NewRootCommand()
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
@@ -94,7 +92,7 @@ func TestReposAdd_PersistsRepo(t *testing.T) {
 }
 
 func TestReposList_ShowsRegisteredRepos(t *testing.T) {
-	_, cfg := reposCtx(t)
+	cfg := reposCtx(t)
 	seedRepo(t, cfg, "acme")
 
 	root := NewRootCommand()
@@ -112,7 +110,7 @@ func TestReposList_ShowsRegisteredRepos(t *testing.T) {
 }
 
 func TestReposList_EmptyState(t *testing.T) {
-	_, cfg := reposCtx(t)
+	cfg := reposCtx(t)
 	root := NewRootCommand()
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
@@ -127,7 +125,7 @@ func TestReposList_EmptyState(t *testing.T) {
 }
 
 func TestReposStatus_ShowsDetails(t *testing.T) {
-	_, cfg := reposCtx(t)
+	cfg := reposCtx(t)
 	seedRepo(t, cfg, "acme")
 
 	root := NewRootCommand()
@@ -147,7 +145,7 @@ func TestReposStatus_ShowsDetails(t *testing.T) {
 }
 
 func TestReposRemove_RequiresYesFlag(t *testing.T) {
-	_, cfg := reposCtx(t)
+	cfg := reposCtx(t)
 	seedRepo(t, cfg, "acme")
 
 	root := NewRootCommand()
@@ -161,7 +159,7 @@ func TestReposRemove_RequiresYesFlag(t *testing.T) {
 }
 
 func TestReposRemove_DeletesRow(t *testing.T) {
-	_, cfg := reposCtx(t)
+	cfg := reposCtx(t)
 	seedRepo(t, cfg, "acme")
 
 	root := NewRootCommand()

--- a/packages/engine/internal/cli/root.go
+++ b/packages/engine/internal/cli/root.go
@@ -56,6 +56,7 @@ Full documentation: https://mantle.dvflw.co/docs`,
 		newLogsCommand(),
 		newStatusCommand(),
 		newEnvCommand(),
+		newReposCommand(),
 	)
 
 	// Server & triggers.

--- a/packages/engine/internal/cli/root.go
+++ b/packages/engine/internal/cli/root.go
@@ -56,7 +56,6 @@ Full documentation: https://mantle.dvflw.co/docs`,
 		newLogsCommand(),
 		newStatusCommand(),
 		newEnvCommand(),
-		newReposCommand(),
 	)
 
 	// Server & triggers.
@@ -83,6 +82,7 @@ Full documentation: https://mantle.dvflw.co/docs`,
 		newLibraryCommand(),
 		newCleanupCommand(),
 		newBudgetCommand(),
+		newReposCommand(),
 	)
 
 	// Info.

--- a/packages/engine/internal/config/config.go
+++ b/packages/engine/internal/config/config.go
@@ -68,9 +68,11 @@ type StorageConfig struct {
 	Retention string `mapstructure:"retention"` // Duration string, e.g. "24h". Empty = no auto-cleanup.
 }
 
-// GitSyncConfig configures GitOps-style workflow sync (issue #16). Each
-// entry under Repos is materialized into a git_repos row at startup so
-// the registry stays consistent with mantle.yaml.
+// GitSyncConfig configures GitOps-style workflow sync (issue #16). Plan A
+// parses and exposes this block so operators can version their repo
+// registry in mantle.yaml; the startup reconciliation that materializes
+// entries into git_repos rows ships with the sync engine in a later
+// milestone.
 type GitSyncConfig struct {
 	Repos []GitSyncRepo `mapstructure:"repos"`
 }

--- a/packages/engine/internal/config/config.go
+++ b/packages/engine/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	GCP        GCPConfig        `mapstructure:"gcp"`
 	Azure      AzureConfig      `mapstructure:"azure"`
 	Storage    StorageConfig    `mapstructure:"storage"`
+	GitSync    GitSyncConfig    `mapstructure:"git_sync"`
 	Env        map[string]string `mapstructure:"env"`
 }
 
@@ -65,6 +66,27 @@ type StorageConfig struct {
 	Prefix    string `mapstructure:"prefix"`    // Key prefix (for type: s3)
 	Path      string `mapstructure:"path"`      // Local directory (for type: filesystem)
 	Retention string `mapstructure:"retention"` // Duration string, e.g. "24h". Empty = no auto-cleanup.
+}
+
+// GitSyncConfig configures GitOps-style workflow sync (issue #16). Each
+// entry under Repos is materialized into a git_repos row at startup so
+// the registry stays consistent with mantle.yaml.
+type GitSyncConfig struct {
+	Repos []GitSyncRepo `mapstructure:"repos"`
+}
+
+// GitSyncRepo mirrors the relevant fields of the git_repos table for
+// config-driven registration. Fields default to the same values as the
+// DB when omitted.
+type GitSyncRepo struct {
+	Name         string `mapstructure:"name"`
+	URL          string `mapstructure:"url"`
+	Branch       string `mapstructure:"branch"`
+	Path         string `mapstructure:"path"`
+	PollInterval string `mapstructure:"poll_interval"`
+	Credential   string `mapstructure:"credential"`
+	AutoApply    bool   `mapstructure:"auto_apply"`
+	Prune        bool   `mapstructure:"prune"`
 }
 
 // AuthConfig holds authentication configuration.

--- a/packages/engine/internal/config/config.go
+++ b/packages/engine/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dvflw/mantle/internal/budget"
 	"github.com/dvflw/mantle/internal/dbdefaults"
 	"github.com/dvflw/mantle/internal/netutil"
+	"github.com/dvflw/mantle/internal/repo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -351,6 +352,30 @@ func Load(cmd *cobra.Command) (*Config, error) {
 			normalized[strings.ToUpper(k)] = v
 		}
 		cfg.Env = normalized
+	}
+
+	// Validate git_sync.repos entries. Each repo must have a valid name,
+	// a valid poll_interval, and a URL free of embedded credentials.
+	// The URL check is intentionally a subset of the store's validateURL:
+	// it only needs to catch the "user@host" form that people may put in a
+	// config file. Full store-level validation runs again at registration time.
+	for i, r := range cfg.GitSync.Repos {
+		if err := repo.ValidateName(r.Name); err != nil {
+			return nil, fmt.Errorf("git_sync.repos[%d]: %w", i, err)
+		}
+		if r.URL == "" {
+			return nil, fmt.Errorf("git_sync.repos[%d] (%q): url is required", i, r.Name)
+		}
+		if parsed, err := url.Parse(r.URL); err != nil {
+			return nil, fmt.Errorf("git_sync.repos[%d] (%q): invalid url: %w", i, r.Name, err)
+		} else if parsed.User != nil {
+			return nil, fmt.Errorf("git_sync.repos[%d] (%q): url must not embed credentials", i, r.Name)
+		}
+		if r.PollInterval != "" {
+			if err := repo.ValidatePollInterval(r.PollInterval); err != nil {
+				return nil, fmt.Errorf("git_sync.repos[%d] (%q): %w", i, r.Name, err)
+			}
+		}
 	}
 
 	// Validate budget reset_day range.

--- a/packages/engine/internal/config/config.go
+++ b/packages/engine/internal/config/config.go
@@ -372,6 +372,9 @@ func Load(cmd *cobra.Command) (*Config, error) {
 		if err := validateGitSyncURL(r.URL); err != nil {
 			return nil, fmt.Errorf("git_sync.repos[%d] (%q): %w", i, r.Name, err)
 		}
+		if r.Credential == "" {
+			return nil, fmt.Errorf("git_sync.repos[%d] (%q): credential is required", i, r.Name)
+		}
 		if r.PollInterval != "" {
 			if err := validateGitSyncPollInterval(r.PollInterval); err != nil {
 				return nil, fmt.Errorf("git_sync.repos[%d] (%q): %w", i, r.Name, err)
@@ -420,6 +423,11 @@ func Load(cmd *cobra.Command) (*Config, error) {
 // kept here to avoid a config → repo → auth test-time import cycle.
 var gitSyncNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$`)
 
+// scpStyleSSHPattern matches scp-style SSH git URLs (e.g. git@github.com:user/repo.git).
+// url.Parse does not recognise these as having a scheme or host, so they need a
+// separate check after the standard parse-based validation.
+var scpStyleSSHPattern = regexp.MustCompile(`^[^@\s]+@[^:\s]+:.+$`)
+
 // validateGitSyncName is a local copy of repo.ValidateName to avoid a
 // config → repo → auth test-time import cycle. Keep in sync with the
 // canonical version in packages/engine/internal/repo/types.go.
@@ -449,9 +457,11 @@ func validateGitSyncPollInterval(interval string) error {
 	return nil
 }
 
-// validateGitSyncURL rejects any URL that embeds credentials in the
-// userinfo component (https://user@host or https://user:pass@host). All
-// auth material must flow through the Credential reference.
+// validateGitSyncURL rejects URLs that embed credentials in the userinfo
+// component (https://user@host or https://user:pass@host) and also rejects
+// strings that are neither a well-formed URL (scheme + host) nor a valid
+// scp-style SSH reference (user@host:path). All auth material must flow
+// through the Credential reference.
 func validateGitSyncURL(raw string) error {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -459,6 +469,11 @@ func validateGitSyncURL(raw string) error {
 	}
 	if u.User != nil {
 		return fmt.Errorf("repo url must not embed credentials — use the Credential field instead")
+	}
+	if u.Scheme == "" || u.Host == "" {
+		if !scpStyleSSHPattern.MatchString(raw) {
+			return fmt.Errorf("invalid url %q: must have scheme and host (e.g. https://host/path) or use scp-style SSH format (git@host:path)", raw)
+		}
 	}
 	return nil
 }

--- a/packages/engine/internal/config/config.go
+++ b/packages/engine/internal/config/config.go
@@ -75,6 +75,9 @@ type StorageConfig struct {
 // entries into git_repos rows ships with the sync engine in a later
 // milestone.
 type GitSyncConfig struct {
+	// Repos is list-valued; Viper cannot bind individual list elements to env
+	// vars, so no BindEnv calls are present for git_sync.repos — this is
+	// intentional. Repos are configured exclusively via the config file.
 	Repos []GitSyncRepo `mapstructure:"repos"`
 }
 

--- a/packages/engine/internal/config/config.go
+++ b/packages/engine/internal/config/config.go
@@ -9,13 +9,13 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/dvflw/mantle/internal/budget"
 	"github.com/dvflw/mantle/internal/dbdefaults"
 	"github.com/dvflw/mantle/internal/netutil"
-	"github.com/dvflw/mantle/internal/repo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -363,19 +363,17 @@ func Load(cmd *cobra.Command) (*Config, error) {
 	// it only needs to catch the "user@host" form that people may put in a
 	// config file. Full store-level validation runs again at registration time.
 	for i, r := range cfg.GitSync.Repos {
-		if err := repo.ValidateName(r.Name); err != nil {
+		if err := validateGitSyncName(r.Name); err != nil {
 			return nil, fmt.Errorf("git_sync.repos[%d]: %w", i, err)
 		}
 		if r.URL == "" {
 			return nil, fmt.Errorf("git_sync.repos[%d] (%q): url is required", i, r.Name)
 		}
-		if parsed, err := url.Parse(r.URL); err != nil {
-			return nil, fmt.Errorf("git_sync.repos[%d] (%q): invalid url: %w", i, r.Name, err)
-		} else if parsed.User != nil {
-			return nil, fmt.Errorf("git_sync.repos[%d] (%q): url must not embed credentials", i, r.Name)
+		if err := validateGitSyncURL(r.URL); err != nil {
+			return nil, fmt.Errorf("git_sync.repos[%d] (%q): %w", i, r.Name, err)
 		}
 		if r.PollInterval != "" {
-			if err := repo.ValidatePollInterval(r.PollInterval); err != nil {
+			if err := validateGitSyncPollInterval(r.PollInterval); err != nil {
 				return nil, fmt.Errorf("git_sync.repos[%d] (%q): %w", i, r.Name, err)
 			}
 		}
@@ -414,4 +412,53 @@ func Load(cmd *cobra.Command) (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+// gitSyncNamePattern enforces DNS-label-like names: lowercase alphanumerics,
+// underscores, and hyphens, starting and ending with an alphanumeric.
+// This is a local copy of the pattern in packages/engine/internal/repo/types.go
+// kept here to avoid a config → repo → auth test-time import cycle.
+var gitSyncNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$`)
+
+// validateGitSyncName is a local copy of repo.ValidateName to avoid a
+// config → repo → auth test-time import cycle. Keep in sync with the
+// canonical version in packages/engine/internal/repo/types.go.
+func validateGitSyncName(name string) error {
+	if name == "" {
+		return fmt.Errorf("repo name is required")
+	}
+	if len(name) > 63 {
+		return fmt.Errorf("invalid repo name %q: length %d exceeds 63-char cap", name, len(name))
+	}
+	if !gitSyncNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid repo name %q: must match %s", name, gitSyncNamePattern.String())
+	}
+	return nil
+}
+
+// validateGitSyncPollInterval is a local copy of repo.ValidatePollInterval.
+// See validateGitSyncName for the rationale.
+func validateGitSyncPollInterval(interval string) error {
+	d, err := time.ParseDuration(interval)
+	if err != nil {
+		return fmt.Errorf("invalid poll_interval %q: %w", interval, err)
+	}
+	if d < 10*time.Second {
+		return fmt.Errorf("poll_interval %q below 10s minimum", interval)
+	}
+	return nil
+}
+
+// validateGitSyncURL rejects any URL that embeds credentials in the
+// userinfo component (https://user@host or https://user:pass@host). All
+// auth material must flow through the Credential reference.
+func validateGitSyncURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid url %q: %w", raw, err)
+	}
+	if u.User != nil {
+		return fmt.Errorf("repo url must not embed credentials — use the Credential field instead")
+	}
+	return nil
 }

--- a/packages/engine/internal/config/config_test.go
+++ b/packages/engine/internal/config/config_test.go
@@ -467,3 +467,39 @@ log:
 
 	assert.Empty(t, cfg.Env)
 }
+
+func TestLoadConfig_GitSyncRepos(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mantle.yaml")
+	yaml := `version: 1
+database:
+  url: postgres://localhost/mantle
+git_sync:
+  repos:
+    - name: acme
+      url: https://github.com/acme/workflows.git
+      branch: main
+      path: /
+      poll_interval: 60s
+      credential: github-pat
+      auto_apply: true
+      prune: true
+`
+	if err := os.WriteFile(path, []byte(yaml), 0600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	cmd := newTestCommand()
+	_ = cmd.Flags().Set("config", path)
+	cfg, err := Load(cmd)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.GitSync.Repos) != 1 {
+		t.Fatalf("got %d repos, want 1", len(cfg.GitSync.Repos))
+	}
+	r := cfg.GitSync.Repos[0]
+	if r.Name != "acme" || r.URL != "https://github.com/acme/workflows.git" ||
+		r.Branch != "main" || r.Credential != "github-pat" || !r.AutoApply {
+		t.Errorf("parsed repo: %+v", r)
+	}
+}

--- a/packages/engine/internal/config/config_test.go
+++ b/packages/engine/internal/config/config_test.go
@@ -502,4 +502,13 @@ git_sync:
 		r.Branch != "main" || r.Credential != "github-pat" || !r.AutoApply {
 		t.Errorf("parsed repo: %+v", r)
 	}
+	if r.Path != "/" {
+		t.Errorf("Path: got %q, want %q", r.Path, "/")
+	}
+	if r.PollInterval != "60s" {
+		t.Errorf("PollInterval: got %q, want %q", r.PollInterval, "60s")
+	}
+	if !r.Prune {
+		t.Errorf("Prune: got false, want true")
+	}
 }

--- a/packages/engine/internal/config/config_test.go
+++ b/packages/engine/internal/config/config_test.go
@@ -512,3 +512,84 @@ git_sync:
 		t.Errorf("Prune: got false, want true")
 	}
 }
+
+func TestLoad_GitSyncRepos_Validation(t *testing.T) {
+	base := `version: 1
+database:
+  url: postgres://localhost/mantle
+git_sync:
+  repos:
+`
+	cases := []struct {
+		name    string
+		repo    string
+		wantErr string
+	}{
+		{
+			name: "invalid name",
+			repo: `    - name: "Bad Name!"
+      url: https://example.com/a.git
+      credential: pat
+`,
+			wantErr: "invalid repo name",
+		},
+		{
+			name: "missing url",
+			repo: `    - name: acme
+      credential: pat
+`,
+			wantErr: "url is required",
+		},
+		{
+			name: "url with embedded credentials",
+			repo: `    - name: acme
+      url: https://user:pass@github.com/a.git
+      credential: pat
+`,
+			wantErr: "must not embed credentials",
+		},
+		{
+			name: "url with no scheme or host",
+			repo: `    - name: acme
+      url: "not a url"
+      credential: pat
+`,
+			wantErr: "must have scheme and host",
+		},
+		{
+			name: "missing credential",
+			repo: `    - name: acme
+      url: https://github.com/a.git
+`,
+			wantErr: "credential is required",
+		},
+		{
+			name: "poll_interval below minimum",
+			repo: `    - name: acme
+      url: https://github.com/a.git
+      credential: pat
+      poll_interval: 5s
+`,
+			wantErr: "below 10s minimum",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "mantle.yaml")
+			if err := os.WriteFile(path, []byte(base+tc.repo), 0600); err != nil {
+				t.Fatalf("writing config: %v", err)
+			}
+			cmd := newTestCommand()
+			_ = cmd.Flags().Set("config", path)
+			_, err := Load(cmd)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/packages/engine/internal/db/migrations/019_git_repos.sql
+++ b/packages/engine/internal/db/migrations/019_git_repos.sql
@@ -1,0 +1,36 @@
+-- +goose Up
+-- git_repos stores configuration for GitOps workflow sources (issue #16).
+-- Each row represents a remote git repository that Mantle will pull from
+-- (via a k8s git-sync sidecar) and whose .yaml/.yml files will be applied
+-- as workflow definitions. The raw auth material lives in credentials —
+-- this row only references it by name.
+--
+-- The `name` column is a human-readable identifier for CLI ergonomics
+-- (`mantle repos status <name>`), unique per team. It does not derive
+-- from the repo URL because multiple teams may share the same upstream.
+CREATE TABLE git_repos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id UUID NOT NULL REFERENCES teams(id) DEFAULT '00000000-0000-0000-0000-000000000001',
+    name TEXT NOT NULL,
+    url TEXT NOT NULL,
+    branch TEXT NOT NULL DEFAULT 'main',
+    path TEXT NOT NULL DEFAULT '/',
+    poll_interval TEXT NOT NULL DEFAULT '60s',
+    credential TEXT NOT NULL,
+    auto_apply BOOLEAN NOT NULL DEFAULT TRUE,
+    prune BOOLEAN NOT NULL DEFAULT TRUE,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    last_sync_sha TEXT,
+    last_sync_at TIMESTAMPTZ,
+    last_sync_error TEXT,
+    webhook_secret TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT git_repos_team_name_key UNIQUE(team_id, name)
+);
+
+CREATE INDEX idx_git_repos_team ON git_repos(team_id);
+CREATE INDEX idx_git_repos_enabled ON git_repos(enabled) WHERE enabled = TRUE;
+
+-- +goose Down
+DROP TABLE IF EXISTS git_repos;

--- a/packages/engine/internal/db/migrations/019_git_repos.sql
+++ b/packages/engine/internal/db/migrations/019_git_repos.sql
@@ -1,13 +1,19 @@
 -- +goose Up
 -- git_repos stores configuration for GitOps workflow sources (issue #16).
 -- Each row represents a remote git repository that Mantle will pull from
--- (via a k8s git-sync sidecar) and whose .yaml/.yml files will be applied
--- as workflow definitions. The raw auth material lives in credentials —
--- this row only references it by name.
+-- and whose .yaml/.yml files will be applied as workflow definitions.
+-- Raw auth material lives in the credentials table; this row references
+-- it by name only.
 --
 -- The `name` column is a human-readable identifier for CLI ergonomics
 -- (`mantle repos status <name>`), unique per team. It does not derive
 -- from the repo URL because multiple teams may share the same upstream.
+--
+-- credential is stored as a plain name reference (TEXT NOT NULL) rather
+-- than a foreign key. A FK to credentials(team_id, name) would prevent
+-- operators from registering a repo before creating the credential, which
+-- is a common IaC pattern (define everything in one pass, then apply).
+-- The sync engine resolves and validates the credential at sync time.
 CREATE TABLE git_repos (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     team_id UUID NOT NULL REFERENCES teams(id) ON DELETE RESTRICT DEFAULT '00000000-0000-0000-0000-000000000001',
@@ -23,7 +29,9 @@ CREATE TABLE git_repos (
     last_sync_sha TEXT,
     last_sync_at TIMESTAMPTZ,
     last_sync_error TEXT,
-    webhook_secret TEXT,
+    -- webhook_secret is intentionally absent in Plan A: the webhook receiver
+    -- (Plan C) will add a new migration that stores the HMAC secret as an
+    -- encrypted credential reference rather than plaintext TEXT.
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT git_repos_team_name_key UNIQUE(team_id, name)

--- a/packages/engine/internal/db/migrations/019_git_repos.sql
+++ b/packages/engine/internal/db/migrations/019_git_repos.sql
@@ -30,7 +30,7 @@ CREATE TABLE git_repos (
 );
 
 CREATE INDEX idx_git_repos_team ON git_repos(team_id);
-CREATE INDEX idx_git_repos_enabled ON git_repos(enabled) WHERE enabled = TRUE;
+CREATE INDEX idx_git_repos_team_enabled ON git_repos(team_id, enabled) WHERE enabled = TRUE;
 
 -- +goose Down
 DROP TABLE IF EXISTS git_repos;

--- a/packages/engine/internal/db/migrations/019_git_repos.sql
+++ b/packages/engine/internal/db/migrations/019_git_repos.sql
@@ -10,7 +10,7 @@
 -- from the repo URL because multiple teams may share the same upstream.
 CREATE TABLE git_repos (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    team_id UUID NOT NULL REFERENCES teams(id) DEFAULT '00000000-0000-0000-0000-000000000001',
+    team_id UUID NOT NULL REFERENCES teams(id) ON DELETE RESTRICT DEFAULT '00000000-0000-0000-0000-000000000001',
     name TEXT NOT NULL,
     url TEXT NOT NULL,
     branch TEXT NOT NULL DEFAULT 'main',

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -211,6 +211,45 @@ func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo,
 	return &r, nil
 }
 
+// Delete removes a repo by name and emits a repo.removed audit event in
+// the same transaction. Returns ErrNotFound when no row matches.
+func (s *Store) Delete(ctx context.Context, name string) error {
+	teamID := auth.TeamIDFromContext(ctx)
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("starting transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var deletedID string
+	err = tx.QueryRowContext(ctx,
+		`DELETE FROM git_repos WHERE name = $1 AND team_id = $2 RETURNING id`,
+		name, teamID,
+	).Scan(&deletedID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+	if err != nil {
+		return fmt.Errorf("deleting repo %q: %w", name, err)
+	}
+
+	if err := audit.EmitTx(ctx, tx, audit.Event{
+		Timestamp: time.Now(),
+		Actor:     s.actor(),
+		Action:    audit.ActionRepoRemoved,
+		Resource:  audit.Resource{Type: "git_repo", ID: deletedID},
+		TeamID:    teamID,
+		Metadata:  map[string]string{"name": name},
+	}); err != nil {
+		return fmt.Errorf("emitting audit event: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing repo delete: %w", err)
+	}
+	return nil
+}
+
 // Get retrieves a repo by name within the current team scope. Returns
 // ErrNotFound when no row matches.
 func (s *Store) Get(ctx context.Context, name string) (*Repo, error) {

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -1,0 +1,101 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dvflw/mantle/internal/audit"
+	"github.com/dvflw/mantle/internal/auth"
+)
+
+// Store handles CRUD operations for registered git repos. Every
+// state-changing method emits an audit event in the same transaction
+// as the write so audit log and state never drift.
+type Store struct {
+	DB    *sql.DB
+	Actor string // defaults to "cli" when empty
+}
+
+func (s *Store) actor() string {
+	if s.Actor == "" {
+		return "cli"
+	}
+	return s.Actor
+}
+
+// ErrNotFound is returned when a lookup by name does not match a row in
+// the current team scope.
+var ErrNotFound = errors.New("repo not found")
+
+// CreateParams captures the fields required to register a new repo.
+// Fields with empty defaults (Branch, Path, PollInterval) are filled
+// in by the caller using the same defaults the `git_repos` table uses.
+type CreateParams struct {
+	Name         string
+	URL          string
+	Branch       string
+	Path         string
+	PollInterval string
+	Credential   string
+	AutoApply    bool
+	Prune        bool
+}
+
+// Create inserts a new repo row and emits a repo.added audit event.
+func (s *Store) Create(ctx context.Context, p CreateParams) (*Repo, error) {
+	if err := ValidateName(p.Name); err != nil {
+		return nil, err
+	}
+	if err := ValidatePollInterval(p.PollInterval); err != nil {
+		return nil, err
+	}
+	if p.URL == "" {
+		return nil, fmt.Errorf("repo url is required")
+	}
+	if p.Credential == "" {
+		return nil, fmt.Errorf("credential is required")
+	}
+
+	teamID := auth.TeamIDFromContext(ctx)
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("starting transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var r Repo
+	err = tx.QueryRowContext(ctx,
+		`INSERT INTO git_repos
+		 (team_id, name, url, branch, path, poll_interval, credential, auto_apply, prune)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 RETURNING id, name, url, branch, path, poll_interval, credential,
+		           auto_apply, prune, enabled, created_at, updated_at`,
+		teamID, p.Name, p.URL, p.Branch, p.Path, p.PollInterval, p.Credential,
+		p.AutoApply, p.Prune,
+	).Scan(&r.ID, &r.Name, &r.URL, &r.Branch, &r.Path, &r.PollInterval,
+		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled,
+		&r.CreatedAt, &r.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("creating repo %q: %w", p.Name, err)
+	}
+
+	if err := audit.EmitTx(ctx, tx, audit.Event{
+		Timestamp: time.Now(),
+		Actor:     s.actor(),
+		Action:    audit.ActionRepoAdded,
+		Resource:  audit.Resource{Type: "git_repo", ID: r.ID},
+		TeamID:    teamID,
+		Metadata:  map[string]string{"name": p.Name, "url": p.URL},
+	}); err != nil {
+		return nil, fmt.Errorf("emitting audit event: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing repo create: %w", err)
+	}
+	return &r, nil
+}

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -100,6 +100,50 @@ func (s *Store) Create(ctx context.Context, p CreateParams) (*Repo, error) {
 	return &r, nil
 }
 
+// List returns all repos in the current team scope, ordered by name.
+// Last-sync fields are populated when non-null. The credential name is
+// returned but raw secret material is never loaded here.
+func (s *Store) List(ctx context.Context) ([]Repo, error) {
+	teamID := auth.TeamIDFromContext(ctx)
+
+	rows, err := s.DB.QueryContext(ctx,
+		`SELECT id, name, url, branch, path, poll_interval, credential,
+		        auto_apply, prune, enabled, last_sync_sha, last_sync_at,
+		        last_sync_error, created_at, updated_at
+		 FROM git_repos WHERE team_id = $1 ORDER BY name`,
+		teamID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing repos: %w", err)
+	}
+	defer rows.Close()
+
+	var repos []Repo
+	for rows.Next() {
+		var r Repo
+		var lastSyncAt sql.NullTime
+		var lastSyncSHA, lastSyncError sql.NullString
+		if err := rows.Scan(&r.ID, &r.Name, &r.URL, &r.Branch, &r.Path,
+			&r.PollInterval, &r.Credential, &r.AutoApply, &r.Prune, &r.Enabled,
+			&lastSyncSHA, &lastSyncAt, &lastSyncError,
+			&r.CreatedAt, &r.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scanning repo: %w", err)
+		}
+		if lastSyncSHA.Valid {
+			r.LastSyncSHA = lastSyncSHA.String
+		}
+		if lastSyncAt.Valid {
+			t := lastSyncAt.Time
+			r.LastSyncAt = &t
+		}
+		if lastSyncError.Valid {
+			r.LastSyncError = lastSyncError.String
+		}
+		repos = append(repos, r)
+	}
+	return repos, rows.Err()
+}
+
 // Get retrieves a repo by name within the current team scope. Returns
 // ErrNotFound when no row matches.
 func (s *Store) Get(ctx context.Context, name string) (*Repo, error) {

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -144,6 +144,73 @@ func (s *Store) List(ctx context.Context) ([]Repo, error) {
 	return repos, rows.Err()
 }
 
+// UpdateParams captures the mutable fields of a repo. Name and URL are
+// intentionally omitted — changing either requires delete + recreate so
+// that audit history clearly reflects the identity change.
+type UpdateParams struct {
+	Branch       string
+	Path         string
+	PollInterval string
+	Credential   string
+	AutoApply    bool
+	Prune        bool
+	Enabled      bool
+}
+
+// Update replaces the mutable fields of a repo by name and emits a
+// repo.updated audit event in the same transaction.
+func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo, error) {
+	if err := ValidatePollInterval(p.PollInterval); err != nil {
+		return nil, err
+	}
+	if p.Credential == "" {
+		return nil, fmt.Errorf("credential is required")
+	}
+
+	teamID := auth.TeamIDFromContext(ctx)
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("starting transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var r Repo
+	err = tx.QueryRowContext(ctx,
+		`UPDATE git_repos
+		 SET branch = $3, path = $4, poll_interval = $5, credential = $6,
+		     auto_apply = $7, prune = $8, enabled = $9, updated_at = NOW()
+		 WHERE name = $1 AND team_id = $2
+		 RETURNING id, name, url, branch, path, poll_interval, credential,
+		           auto_apply, prune, enabled, created_at, updated_at`,
+		name, teamID, p.Branch, p.Path, p.PollInterval, p.Credential,
+		p.AutoApply, p.Prune, p.Enabled,
+	).Scan(&r.ID, &r.Name, &r.URL, &r.Branch, &r.Path, &r.PollInterval,
+		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled,
+		&r.CreatedAt, &r.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("updating repo %q: %w", name, err)
+	}
+
+	if err := audit.EmitTx(ctx, tx, audit.Event{
+		Timestamp: time.Now(),
+		Actor:     s.actor(),
+		Action:    audit.ActionRepoUpdated,
+		Resource:  audit.Resource{Type: "git_repo", ID: r.ID},
+		TeamID:    teamID,
+		Metadata:  map[string]string{"name": name},
+	}); err != nil {
+		return nil, fmt.Errorf("emitting audit event: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing repo update: %w", err)
+	}
+	return &r, nil
+}
+
 // Get retrieves a repo by name within the current team scope. Returns
 // ErrNotFound when no row matches.
 func (s *Store) Get(ctx context.Context, name string) (*Repo, error) {

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -99,3 +99,43 @@ func (s *Store) Create(ctx context.Context, p CreateParams) (*Repo, error) {
 	}
 	return &r, nil
 }
+
+// Get retrieves a repo by name within the current team scope. Returns
+// ErrNotFound when no row matches.
+func (s *Store) Get(ctx context.Context, name string) (*Repo, error) {
+	teamID := auth.TeamIDFromContext(ctx)
+
+	var r Repo
+	var lastSyncAt sql.NullTime
+	var lastSyncSHA, lastSyncError, webhookSecret sql.NullString
+	err := s.DB.QueryRowContext(ctx,
+		`SELECT id, name, url, branch, path, poll_interval, credential,
+		        auto_apply, prune, enabled, last_sync_sha, last_sync_at,
+		        last_sync_error, webhook_secret, created_at, updated_at
+		 FROM git_repos WHERE name = $1 AND team_id = $2`,
+		name, teamID,
+	).Scan(&r.ID, &r.Name, &r.URL, &r.Branch, &r.Path, &r.PollInterval,
+		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled,
+		&lastSyncSHA, &lastSyncAt, &lastSyncError, &webhookSecret,
+		&r.CreatedAt, &r.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying repo: %w", err)
+	}
+	if lastSyncSHA.Valid {
+		r.LastSyncSHA = lastSyncSHA.String
+	}
+	if lastSyncAt.Valid {
+		t := lastSyncAt.Time
+		r.LastSyncAt = &t
+	}
+	if lastSyncError.Valid {
+		r.LastSyncError = lastSyncError.String
+	}
+	if webhookSecret.Valid {
+		r.WebhookSecret = webhookSecret.String
+	}
+	return &r, nil
+}

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/dvflw/mantle/internal/audit"
@@ -57,6 +58,9 @@ func (s *Store) Create(ctx context.Context, p CreateParams) (*Repo, error) {
 	}
 	if p.Credential == "" {
 		return nil, fmt.Errorf("credential is required")
+	}
+	if err := validateURL(p.URL); err != nil {
+		return nil, err
 	}
 
 	teamID := auth.TeamIDFromContext(ctx)
@@ -246,6 +250,23 @@ func (s *Store) Delete(ctx context.Context, name string) error {
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("committing repo delete: %w", err)
+	}
+	return nil
+}
+
+// validateURL rejects URLs that embed credentials inline (the `user:pass@host`
+// form). Operators must put credential material in a "git" secret and
+// reference it via the Credential field, never inline in the URL, so we
+// don't risk persisting or displaying tokens that live in git_repos.url.
+func validateURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid url %q: %w", raw, err)
+	}
+	if u.User != nil {
+		if _, hasPassword := u.User.Password(); hasPassword {
+			return fmt.Errorf("repo url must not embed credentials — use the --credential flag instead")
+		}
 	}
 	return nil
 }

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -254,19 +254,19 @@ func (s *Store) Delete(ctx context.Context, name string) error {
 	return nil
 }
 
-// validateURL rejects URLs that embed credentials inline (the `user:pass@host`
-// form). Operators must put credential material in a "git" secret and
-// reference it via the Credential field, never inline in the URL, so we
-// don't risk persisting or displaying tokens that live in git_repos.url.
+// validateURL rejects URLs that embed any userinfo (user or user:pass).
+// GitHub PATs are valid as a username in HTTPS URLs, so even a bare
+// "user@host" form must be rejected. Operators must store credential
+// material in a "git" secret and reference it via the Credential field,
+// never inline in the URL, so we don't risk persisting or displaying
+// tokens that live in git_repos.url.
 func validateURL(raw string) error {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("invalid url %q: %w", raw, err)
 	}
 	if u.User != nil {
-		if _, hasPassword := u.User.Password(); hasPassword {
-			return fmt.Errorf("repo url must not embed credentials — use the --credential flag instead")
-		}
+		return fmt.Errorf("repo url must not embed credentials — use the --credential flag instead")
 	}
 	return nil
 }

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -162,7 +162,9 @@ type UpdateParams struct {
 }
 
 // Update replaces the mutable fields of a repo by name and emits a
-// repo.updated audit event in the same transaction.
+// repo.updated audit event in the same transaction. Empty Branch/Path
+// are treated as "keep existing" — the SQL preserves the stored value
+// rather than overwriting it with an empty string.
 func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo, error) {
 	if err := ValidatePollInterval(p.PollInterval); err != nil {
 		return nil, err
@@ -184,7 +186,9 @@ func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo,
 	var lastSyncSHA, lastSyncError, webhookSecret sql.NullString
 	err = tx.QueryRowContext(ctx,
 		`UPDATE git_repos
-		 SET branch = $3, path = $4, poll_interval = $5, credential = $6,
+		 SET branch       = CASE WHEN $3 = '' THEN branch ELSE $3 END,
+		     path         = CASE WHEN $4 = '' THEN path   ELSE $4 END,
+		     poll_interval = $5, credential = $6,
 		     auto_apply = $7, prune = $8, enabled = $9, updated_at = NOW()
 		 WHERE name = $1 AND team_id = $2
 		 RETURNING id, name, url, branch, path, poll_interval, credential,

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -183,7 +183,7 @@ func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo,
 
 	var r Repo
 	var lastSyncAt sql.NullTime
-	var lastSyncSHA, lastSyncError, webhookSecret sql.NullString
+	var lastSyncSHA, lastSyncError sql.NullString
 	err = tx.QueryRowContext(ctx,
 		`UPDATE git_repos
 		 SET branch       = CASE WHEN $3 = '' THEN branch ELSE $3 END,
@@ -193,12 +193,12 @@ func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo,
 		 WHERE name = $1 AND team_id = $2
 		 RETURNING id, name, url, branch, path, poll_interval, credential,
 		           auto_apply, prune, enabled, last_sync_sha, last_sync_at,
-		           last_sync_error, webhook_secret, created_at, updated_at`,
+		           last_sync_error, created_at, updated_at`,
 		name, teamID, p.Branch, p.Path, p.PollInterval, p.Credential,
 		p.AutoApply, p.Prune, p.Enabled,
 	).Scan(&r.ID, &r.Name, &r.URL, &r.Branch, &r.Path, &r.PollInterval,
 		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled,
-		&lastSyncSHA, &lastSyncAt, &lastSyncError, &webhookSecret,
+		&lastSyncSHA, &lastSyncAt, &lastSyncError,
 		&r.CreatedAt, &r.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("%w: %q", ErrNotFound, name)
@@ -215,9 +215,6 @@ func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo,
 	}
 	if lastSyncError.Valid {
 		r.LastSyncError = lastSyncError.String
-	}
-	if webhookSecret.Valid {
-		r.WebhookSecret = webhookSecret.String
 	}
 
 	if err := audit.EmitTx(ctx, tx, audit.Event{
@@ -299,16 +296,16 @@ func (s *Store) Get(ctx context.Context, name string) (*Repo, error) {
 
 	var r Repo
 	var lastSyncAt sql.NullTime
-	var lastSyncSHA, lastSyncError, webhookSecret sql.NullString
+	var lastSyncSHA, lastSyncError sql.NullString
 	err := s.DB.QueryRowContext(ctx,
 		`SELECT id, name, url, branch, path, poll_interval, credential,
 		        auto_apply, prune, enabled, last_sync_sha, last_sync_at,
-		        last_sync_error, webhook_secret, created_at, updated_at
+		        last_sync_error, created_at, updated_at
 		 FROM git_repos WHERE name = $1 AND team_id = $2`,
 		name, teamID,
 	).Scan(&r.ID, &r.Name, &r.URL, &r.Branch, &r.Path, &r.PollInterval,
 		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled,
-		&lastSyncSHA, &lastSyncAt, &lastSyncError, &webhookSecret,
+		&lastSyncSHA, &lastSyncAt, &lastSyncError,
 		&r.CreatedAt, &r.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("%w: %q", ErrNotFound, name)
@@ -325,9 +322,6 @@ func (s *Store) Get(ctx context.Context, name string) (*Repo, error) {
 	}
 	if lastSyncError.Valid {
 		r.LastSyncError = lastSyncError.String
-	}
-	if webhookSecret.Valid {
-		r.WebhookSecret = webhookSecret.String
 	}
 	return &r, nil
 }

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -180,23 +180,40 @@ func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo,
 	defer tx.Rollback() //nolint:errcheck
 
 	var r Repo
+	var lastSyncAt sql.NullTime
+	var lastSyncSHA, lastSyncError, webhookSecret sql.NullString
 	err = tx.QueryRowContext(ctx,
 		`UPDATE git_repos
 		 SET branch = $3, path = $4, poll_interval = $5, credential = $6,
 		     auto_apply = $7, prune = $8, enabled = $9, updated_at = NOW()
 		 WHERE name = $1 AND team_id = $2
 		 RETURNING id, name, url, branch, path, poll_interval, credential,
-		           auto_apply, prune, enabled, created_at, updated_at`,
+		           auto_apply, prune, enabled, last_sync_sha, last_sync_at,
+		           last_sync_error, webhook_secret, created_at, updated_at`,
 		name, teamID, p.Branch, p.Path, p.PollInterval, p.Credential,
 		p.AutoApply, p.Prune, p.Enabled,
 	).Scan(&r.ID, &r.Name, &r.URL, &r.Branch, &r.Path, &r.PollInterval,
 		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled,
+		&lastSyncSHA, &lastSyncAt, &lastSyncError, &webhookSecret,
 		&r.CreatedAt, &r.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("%w: %q", ErrNotFound, name)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("updating repo %q: %w", name, err)
+	}
+	if lastSyncSHA.Valid {
+		r.LastSyncSHA = lastSyncSHA.String
+	}
+	if lastSyncAt.Valid {
+		t := lastSyncAt.Time
+		r.LastSyncAt = &t
+	}
+	if lastSyncError.Valid {
+		r.LastSyncError = lastSyncError.String
+	}
+	if webhookSecret.Valid {
+		r.WebhookSecret = webhookSecret.String
 	}
 
 	if err := audit.EmitTx(ctx, tx, audit.Event{

--- a/packages/engine/internal/repo/store_test.go
+++ b/packages/engine/internal/repo/store_test.go
@@ -267,3 +267,27 @@ func TestStore_Delete_NotFound(t *testing.T) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
+
+func TestStore_Create_RejectsURLWithPassword(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	_, err := store.Create(ctx, CreateParams{
+		Name: "leaky", URL: "https://user:secret@github.com/acme/wf.git",
+		Branch: "main", Path: "/", PollInterval: "60s", Credential: "pat",
+	})
+	if err == nil {
+		t.Error("expected url-credential rejection")
+	}
+}
+
+func TestStore_Create_AllowsURLWithUsernameOnly(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	// GitHub HTTPS URLs often contain a username hint but no password — fine.
+	if _, err := store.Create(ctx, CreateParams{
+		Name: "ok", URL: "https://acme@github.com/acme/wf.git",
+		Branch: "main", Path: "/", PollInterval: "60s", Credential: "pat",
+	}); err != nil {
+		t.Errorf("username-only URL should be allowed: %v", err)
+	}
+}

--- a/packages/engine/internal/repo/store_test.go
+++ b/packages/engine/internal/repo/store_test.go
@@ -1,0 +1,147 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dvflw/mantle/internal/config"
+	"github.com/dvflw/mantle/internal/db"
+	"github.com/dvflw/mantle/internal/dbdefaults"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// setupTestDB spins up a Postgres container, runs migrations, and returns
+// the connection. Copied from internal/environment/store_test.go to keep
+// both packages decoupled from a shared test helper.
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	ctx := context.Background()
+	pgContainer, err := postgres.Run(ctx,
+		dbdefaults.PostgresImage,
+		postgres.WithDatabase(dbdefaults.TestDatabase),
+		postgres.WithUsername(dbdefaults.User),
+		postgres.WithPassword(dbdefaults.Password),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+	)
+	if err != nil {
+		if os.Getenv("CI") != "" {
+			t.Fatalf("Could not start Postgres container (CI): %v", err)
+		}
+		t.Skipf("Could not start Postgres container: %v", err)
+	}
+	t.Cleanup(func() { _ = pgContainer.Terminate(ctx) })
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("ConnectionString: %v", err)
+	}
+	database, err := db.Open(config.DatabaseConfig{URL: connStr})
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	if err := db.Migrate(ctx, database); err != nil {
+		t.Fatalf("db.Migrate: %v", err)
+	}
+	return database
+}
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return &Store{DB: setupTestDB(t), Actor: "test"}
+}
+
+// defaultCtx returns the default single-tenant test context. TeamIDFromContext
+// returns auth.DefaultTeamID when no authenticated user is present, which
+// matches the FK default on git_repos.
+func defaultCtx() context.Context {
+	return context.Background()
+}
+
+func TestStore_Create_PersistsRow(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+
+	r, err := store.Create(ctx, CreateParams{
+		Name:         "acme",
+		URL:          "https://github.com/acme/workflows.git",
+		Branch:       "main",
+		Path:         "/",
+		PollInterval: "60s",
+		Credential:   "github-pat",
+		AutoApply:    true,
+		Prune:        true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if r.ID == "" {
+		t.Error("expected generated ID")
+	}
+	if r.Name != "acme" {
+		t.Errorf("Name: got %q, want %q", r.Name, "acme")
+	}
+	if !r.Enabled {
+		t.Error("Enabled should default to true")
+	}
+}
+
+func TestStore_Create_RejectsDuplicateName(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	base := CreateParams{
+		Name:         "dup",
+		URL:          "https://example.com/a.git",
+		Branch:       "main",
+		Path:         "/",
+		PollInterval: "60s",
+		Credential:   "pat",
+	}
+	if _, err := store.Create(ctx, base); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	if _, err := store.Create(ctx, base); err == nil {
+		t.Error("expected duplicate-name error")
+	}
+}
+
+func TestStore_Create_ValidatesName(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	_, err := store.Create(ctx, CreateParams{
+		Name:         "Bad Name!",
+		URL:          "https://example.com/a.git",
+		Branch:       "main",
+		Path:         "/",
+		PollInterval: "60s",
+		Credential:   "pat",
+	})
+	if err == nil {
+		t.Error("expected name validation error")
+	}
+}
+
+func TestStore_Create_ValidatesPollInterval(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	_, err := store.Create(ctx, CreateParams{
+		Name:         "slow",
+		URL:          "https://example.com/a.git",
+		Branch:       "main",
+		Path:         "/",
+		PollInterval: "5s",
+		Credential:   "pat",
+	})
+	if err == nil {
+		t.Error("expected poll_interval floor error")
+	}
+}
+

--- a/packages/engine/internal/repo/store_test.go
+++ b/packages/engine/internal/repo/store_test.go
@@ -177,3 +177,34 @@ func TestStore_Get_NotFound(t *testing.T) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
+
+func TestStore_List_ReturnsAllReposForTeam(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	for _, name := range []string{"zeta", "alpha", "mike"} {
+		if _, err := store.Create(ctx, CreateParams{
+			Name:         name,
+			URL:          "https://example.com/" + name + ".git",
+			Branch:       "main",
+			Path:         "/",
+			PollInterval: "60s",
+			Credential:   "pat",
+		}); err != nil {
+			t.Fatalf("Create %s: %v", name, err)
+		}
+	}
+	repos, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(repos) != 3 {
+		t.Fatalf("len: got %d, want 3", len(repos))
+	}
+	// ORDER BY name — alpha, mike, zeta.
+	want := []string{"alpha", "mike", "zeta"}
+	for i, r := range repos {
+		if r.Name != want[i] {
+			t.Errorf("index %d: got %q, want %q", i, r.Name, want[i])
+		}
+	}
+}

--- a/packages/engine/internal/repo/store_test.go
+++ b/packages/engine/internal/repo/store_test.go
@@ -242,3 +242,28 @@ func TestStore_Update_NotFound(t *testing.T) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
+
+func TestStore_Delete_RemovesRow(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	if _, err := store.Create(ctx, CreateParams{
+		Name: "acme", URL: "https://example.com/a.git", Branch: "main",
+		Path: "/", PollInterval: "60s", Credential: "pat",
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Delete(ctx, "acme"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Get(ctx, "acme"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestStore_Delete_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	if err := store.Delete(ctx, "nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/packages/engine/internal/repo/store_test.go
+++ b/packages/engine/internal/repo/store_test.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -145,3 +146,34 @@ func TestStore_Create_ValidatesPollInterval(t *testing.T) {
 	}
 }
 
+func TestStore_Get_ReturnsRow(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	created, err := store.Create(ctx, CreateParams{
+		Name:         "acme",
+		URL:          "https://github.com/acme/workflows.git",
+		Branch:       "main",
+		Path:         "/",
+		PollInterval: "60s",
+		Credential:   "pat",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := store.Get(ctx, "acme")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != created.ID {
+		t.Errorf("ID: got %q, want %q", got.ID, created.ID)
+	}
+}
+
+func TestStore_Get_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	_, err := store.Get(ctx, "nope")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/packages/engine/internal/repo/store_test.go
+++ b/packages/engine/internal/repo/store_test.go
@@ -208,3 +208,37 @@ func TestStore_List_ReturnsAllReposForTeam(t *testing.T) {
 		}
 	}
 }
+
+func TestStore_Update_ReplacesMutableFields(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	if _, err := store.Create(ctx, CreateParams{
+		Name: "acme", URL: "https://example.com/a.git", Branch: "main",
+		Path: "/", PollInterval: "60s", Credential: "pat", AutoApply: true, Prune: true,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	updated, err := store.Update(ctx, "acme", UpdateParams{
+		Branch: "release", Path: "/workflows", PollInterval: "120s",
+		Credential: "pat-v2", AutoApply: false, Prune: false, Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Branch != "release" || updated.Path != "/workflows" ||
+		updated.PollInterval != "120s" || updated.Credential != "pat-v2" ||
+		updated.AutoApply || updated.Prune {
+		t.Errorf("Update did not persist fields: %+v", updated)
+	}
+}
+
+func TestStore_Update_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	_, err := store.Update(ctx, "nope", UpdateParams{
+		Branch: "main", Path: "/", PollInterval: "60s", Credential: "pat",
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/packages/engine/internal/repo/store_test.go
+++ b/packages/engine/internal/repo/store_test.go
@@ -280,14 +280,16 @@ func TestStore_Create_RejectsURLWithPassword(t *testing.T) {
 	}
 }
 
-func TestStore_Create_AllowsURLWithUsernameOnly(t *testing.T) {
+func TestStore_Create_RejectsURLWithUsernameOnly(t *testing.T) {
 	store := newTestStore(t)
 	ctx := defaultCtx()
-	// GitHub HTTPS URLs often contain a username hint but no password — fine.
-	if _, err := store.Create(ctx, CreateParams{
-		Name: "ok", URL: "https://acme@github.com/acme/wf.git",
+	// GitHub PATs are valid in the username position for HTTPS — we still reject
+	// them so no credential material ever lives in git_repos.url.
+	_, err := store.Create(ctx, CreateParams{
+		Name: "leaky2", URL: "https://acme@github.com/acme/wf.git",
 		Branch: "main", Path: "/", PollInterval: "60s", Credential: "pat",
-	}); err != nil {
-		t.Errorf("username-only URL should be allowed: %v", err)
+	})
+	if err == nil {
+		t.Error("expected url-credential rejection for username-only URL")
 	}
 }

--- a/packages/engine/internal/repo/types.go
+++ b/packages/engine/internal/repo/types.go
@@ -36,6 +36,10 @@ type Repo struct {
 	LastSyncSHA   string
 	LastSyncAt    *time.Time
 	LastSyncError string
+	// WebhookSecret is the HMAC shared secret used to verify inbound push
+	// webhooks from the git provider. SECURITY: this value is sensitive and
+	// MUST NOT be printed to terminal or logs. The CLI intentionally never
+	// renders it; any new caller must follow the same discipline.
 	WebhookSecret string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time

--- a/packages/engine/internal/repo/types.go
+++ b/packages/engine/internal/repo/types.go
@@ -1,0 +1,74 @@
+// Package repo manages registered GitOps source repositories (issue #16).
+// Each Repo references encrypted auth material in the credentials table
+// by name and stores last-sync state for observability. The sync engine
+// itself (file discovery, validate/plan/apply pipeline) lives in a
+// separate package and is out of scope for this package.
+package repo
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+)
+
+// maxRepoNameLength caps names at the DNS label limit (RFC 1035) — same
+// rationale as environments: names embed into log lines, metric labels,
+// and URL path segments without escaping.
+const maxRepoNameLength = 63
+
+// validRepoNamePattern enforces DNS-label-like names: lowercase
+// alphanumerics, underscores, and hyphens, starting with an alphanumeric.
+var validRepoNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+
+// Repo represents a registered git repository that Mantle pulls workflow
+// definitions from.
+type Repo struct {
+	ID            string
+	Name          string
+	URL           string
+	Branch        string
+	Path          string
+	PollInterval  string // Go duration literal, e.g., "60s"
+	Credential    string // name of the git-type credential row
+	AutoApply     bool
+	Prune         bool
+	Enabled       bool
+	LastSyncSHA   string
+	LastSyncAt    *time.Time
+	LastSyncError string
+	WebhookSecret string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+// ValidateName returns an error when name violates the allowed pattern
+// or length. Exported because the CLI validates the flag before calling
+// into the store for faster feedback on typos.
+func ValidateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("repo name is required")
+	}
+	if len(name) > maxRepoNameLength {
+		return fmt.Errorf("invalid repo name %q: length %d exceeds %d-char cap",
+			name, len(name), maxRepoNameLength)
+	}
+	if !validRepoNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid repo name %q: must match %s",
+			name, validRepoNamePattern.String())
+	}
+	return nil
+}
+
+// ValidatePollInterval returns an error when interval cannot be parsed
+// as a Go duration or is below the 10-second minimum. The floor exists
+// to prevent operators from hammering their git provider's rate limits.
+func ValidatePollInterval(interval string) error {
+	d, err := time.ParseDuration(interval)
+	if err != nil {
+		return fmt.Errorf("invalid poll_interval %q: %w", interval, err)
+	}
+	if d < 10*time.Second {
+		return fmt.Errorf("poll_interval %q below 10s minimum", interval)
+	}
+	return nil
+}

--- a/packages/engine/internal/repo/types.go
+++ b/packages/engine/internal/repo/types.go
@@ -17,8 +17,9 @@ import (
 const maxRepoNameLength = 63
 
 // validRepoNamePattern enforces DNS-label-like names: lowercase
-// alphanumerics, underscores, and hyphens, starting with an alphanumeric.
-var validRepoNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+// alphanumerics, underscores, and hyphens, starting and ending with an
+// alphanumeric. Single-character names (pure alnum) are allowed.
+var validRepoNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$`)
 
 // Repo represents a registered git repository that Mantle pulls workflow
 // definitions from.

--- a/packages/engine/internal/repo/types.go
+++ b/packages/engine/internal/repo/types.go
@@ -37,11 +37,6 @@ type Repo struct {
 	LastSyncSHA   string
 	LastSyncAt    *time.Time
 	LastSyncError string
-	// WebhookSecret is the HMAC shared secret used to verify inbound push
-	// webhooks from the git provider. SECURITY: this value is sensitive and
-	// MUST NOT be printed to terminal or logs. The CLI intentionally never
-	// renders it; any new caller must follow the same discipline.
-	WebhookSecret string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 }

--- a/packages/engine/internal/secret/types.go
+++ b/packages/engine/internal/secret/types.go
@@ -14,8 +14,9 @@ type FieldDef struct {
 
 // CredentialType defines the schema for a credential type.
 type CredentialType struct {
-	Name   string
-	Fields []FieldDef
+	Name              string
+	Fields            []FieldDef
+	RequireAtLeastOne []string // at least one of these field names must be non-empty
 }
 
 // Validate checks that all required fields are present in the data map.
@@ -26,6 +27,19 @@ func (ct *CredentialType) Validate(data map[string]string) error {
 			if !ok || v == "" {
 				return fmt.Errorf("field %q is required for credential type %q", f.Name, ct.Name)
 			}
+		}
+	}
+	if len(ct.RequireAtLeastOne) > 0 {
+		anySet := false
+		for _, name := range ct.RequireAtLeastOne {
+			if v, ok := data[name]; ok && v != "" {
+				anySet = true
+				break
+			}
+		}
+		if !anySet {
+			return fmt.Errorf("credential type %q requires at least one of: %s",
+				ct.Name, strings.Join(ct.RequireAtLeastOne, ", "))
 		}
 	}
 	return nil
@@ -85,6 +99,16 @@ var builtinTypes = map[string]*CredentialType{
 			{Name: "client_cert", Required: false},
 			{Name: "client_key", Required: false},
 		},
+	},
+	"git": {
+		Name: "git",
+		Fields: []FieldDef{
+			{Name: "token", Required: false},
+			{Name: "ssh_key", Required: false},
+			{Name: "username", Required: false},
+		},
+		// At-least-one validator below guarantees we have auth material.
+		RequireAtLeastOne: []string{"token", "ssh_key"},
 	},
 }
 

--- a/packages/engine/internal/secret/types_test.go
+++ b/packages/engine/internal/secret/types_test.go
@@ -41,7 +41,7 @@ func TestGetType_Unknown(t *testing.T) {
 }
 
 func TestGetType_AllBuiltins(t *testing.T) {
-	for _, name := range []string{"generic", "bearer", "openai", "basic"} {
+	for _, name := range []string{"generic", "bearer", "openai", "basic", "git"} {
 		ct, err := GetType(name)
 		if err != nil {
 			t.Errorf("GetType(%q) error: %v", name, err)
@@ -74,5 +74,50 @@ func TestCredentialType_Docker(t *testing.T) {
 		"client_key":  "key-data",
 	}); err != nil {
 		t.Errorf("full TLS data should be valid: %v", err)
+	}
+}
+
+func TestGitCredentialType_Fields(t *testing.T) {
+	ct, err := GetType("git")
+	if err != nil {
+		t.Fatalf("GetType(\"git\") error: %v", err)
+	}
+	want := map[string]bool{
+		"token":    false,
+		"ssh_key":  false,
+		"username": false,
+	}
+	got := map[string]bool{}
+	for _, f := range ct.Fields {
+		got[f.Name] = f.Required
+	}
+	if len(got) != len(want) {
+		t.Fatalf("git type fields: got %v, want %v", got, want)
+	}
+	for name, required := range want {
+		if gotReq, ok := got[name]; !ok {
+			t.Errorf("git type missing field %q", name)
+		} else if gotReq != required {
+			t.Errorf("field %q required: got %v, want %v", name, gotReq, required)
+		}
+	}
+}
+
+func TestGitCredentialType_ValidateRequiresTokenOrSSHKey(t *testing.T) {
+	ct, err := GetType("git")
+	if err != nil {
+		t.Fatalf("GetType(\"git\") error: %v", err)
+	}
+	// Neither token nor ssh_key — should fail.
+	if err := ct.Validate(map[string]string{"username": "git"}); err == nil {
+		t.Error("expected error when both token and ssh_key are empty")
+	}
+	// token-only — should succeed.
+	if err := ct.Validate(map[string]string{"token": "ghp_xxx"}); err != nil {
+		t.Errorf("token-only: unexpected error %v", err)
+	}
+	// ssh_key-only — should succeed.
+	if err := ct.Validate(map[string]string{"ssh_key": "----BEGIN KEY----"}); err != nil {
+		t.Errorf("ssh_key-only: unexpected error %v", err)
 	}
 }

--- a/packages/engine/internal/secret/types_test.go
+++ b/packages/engine/internal/secret/types_test.go
@@ -112,6 +112,10 @@ func TestGitCredentialType_ValidateRequiresTokenOrSSHKey(t *testing.T) {
 	if err := ct.Validate(map[string]string{"username": "git"}); err == nil {
 		t.Error("expected error when both token and ssh_key are empty")
 	}
+	// Explicitly empty strings for both — should also fail.
+	if err := ct.Validate(map[string]string{"token": "", "ssh_key": ""}); err == nil {
+		t.Error("expected error when token and ssh_key are both present but empty")
+	}
 	// token-only — should succeed.
 	if err := ct.Validate(map[string]string{"token": "ghp_xxx"}); err != nil {
 		t.Errorf("token-only: unexpected error %v", err)


### PR DESCRIPTION
## Summary

Plan A of 3 for issue #16 (GitOps sync, milestone v0.5.0). Ships the foundation — no sync behavior yet; that's Plan B.

- Adds `git` credential type with token/ssh_key/username fields and at-least-one-of validation
- Adds `git_repos` table (migration 019) and `internal/repo` CRUD store with transactional audit emission
- Adds `git_sync.repos` block to `mantle.yaml` (parsed-only; startup reconciliation lands with Plan B)
- Adds `mantle repos add | list | status | remove` CLI commands
- Emits `repo.added`, `repo.updated`, `repo.removed` audit events

**Plan breakdown**
- **Plan A (this PR):** Foundation — registry + CLI + config block.
- **Plan B (next):** Sync engine — sidecar integration, file discovery, validate/plan/apply pipeline, prune, `repos sync`.
- **Plan C (after B):** Webhook receiver (`POST /hooks/git/<id>`), REST API (`POST /api/v1/repos`), metrics.

## What operators can do today

- Register repos: `mantle repos add acme --url https://github.com/acme/wf.git --credential github-pat`
- List and inspect: `mantle repos list`, `mantle repos status acme`
- Remove: `mantle repos remove acme --yes`
- Version repos in `mantle.yaml` under `git_sync.repos:` (parsed, not yet materialized — Plan B)

Last-sync fields (`last_sync_sha`, `last_sync_at`, `last_sync_error`, `webhook_secret`) are in the schema but stay null until Plan B/C populate them.

## Pre-push review fixes

Four reviewer agents ran before pushing (Technical Writer, Product Manager, Legal Compliance, Reality Checker). Consolidated fixes landed in 431f822:

- Drop "periodically pulled by the git-sync sidecar" overclaim in CLI Long, config doc, and CLAUDE.md; add Plan A scope caveats
- Rewrite `--prune` flag help to describe the positive-default behavior
- Mark `WebhookSecret` field on `Repo` struct with a SECURITY comment
- Reject repo URLs that embed credentials inline (e.g., `https://user:pass@host/...`)

## Test plan

- [x] `go test ./...` from `packages/engine` — all packages green
- [x] `go test ./internal/repo/ -v` — 13 tests pass (CRUD + validation + URL sanitization)
- [x] `go test ./internal/cli/ -v` — 6 `TestRepos*` CLI tests pass
- [x] `go test ./internal/config/ -v` — `TestLoadConfig_GitSyncRepos` passes
- [x] `go build ./cmd/mantle && ./mantle repos --help` surfaces all four subcommands
- [ ] Manual: `mantle repos add` persists a row; `mantle repos list` shows it; `mantle repos status` prints detail; `mantle repos remove --yes` deletes and emits `repo.removed` audit event

Closes part of #16. Plans B and C follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitOps repo management via CLI: add, list, status, remove (with confirmation) and persistent repo registry; readable list/status output with timestamps and errors.

* **Config**
  * Configurable repos in mantle.yaml: name, URL, branch, path, poll interval, credential, auto-apply, prune, enabled.

* **Security / Credentials**
  * New Git credential type accepting token or SSH key (username optional); validation requires token or ssh_key.

* **Database**
  * Added persistent storage schema for registered repos with sync metadata.

* **Tests**
  * Integration and unit tests for CLI, store, config, and credential validation.

* **Documentation**
  * Updated docs describing CLI commands and GitOps config usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->