### PR TITLE
feat: git sync — webhook, prune, manual flow (Plan C of issue #16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,9 @@ mantle repos list              # List registered repos with last-sync status
 mantle repos status <name>     # Show detailed repo status
 mantle repos remove <name> -y  # Unregister a repo (requires --yes)
 mantle repos sync <name>       # Force an immediate sync of a registered repo
+mantle repos plan <name>       # Dry-run: show what a sync would change
+mantle repos apply <name>      # Manual sync (for auto_apply:false repos)
+mantle repos update <name> --credential <cred>  # Update a repo's mutable fields
 mantle run <wf> --values f.yaml   # Run with a values file (inputs + env overrides)
 mantle run <wf> --env <name>      # Run against a stored named environment
 mantle plan <wf> --env <name>     # Plan; appends resolved inputs/env with source
@@ -115,7 +118,7 @@ git_sync:
 
 Credentials of type `git` accept `token` (for HTTPS), `ssh_key` (for SSH), and optional `username`. At least one of `token` or `ssh_key` is required.
 
-> Plan A shipped the repo registry and CLI. Plan B ships the sync engine — when `mantle serve` runs, it reconciles this block into `git_repos` rows and then polls each enabled `auto_apply: true` repo every `poll_interval`, applying any changed workflow YAML. Force an immediate sync with `mantle repos sync <name>`.
+> **GitOps is fully shipped.** `mantle serve` reconciles this block into `git_repos` rows, then polls each enabled `auto_apply: true` repo every `poll_interval`. Workflows removed from the repo are disabled automatically when `prune: true`. Force an on-demand sync via `mantle repos sync <name>`, preview with `mantle repos plan <name>`, or manually apply via `mantle repos apply <name>`. Register push webhooks from GitHub / GitLab / Gitea pointing at `POST /hooks/git/<repo-id>` with `webhook_secret` set on the repo to trigger immediate syncs — Mantle verifies the HMAC signature via `X-Hub-Signature-256`.
 
 ## License
 

--- a/packages/engine/internal/audit/audit.go
+++ b/packages/engine/internal/audit/audit.go
@@ -72,6 +72,8 @@ const (
 	ActionGitSyncFailed           Action = "git.sync.failed"
 	ActionGitSyncValidationFailed Action = "git.sync.validation_failed"
 	ActionGitSyncApplyFailed      Action = "git.sync.apply_failed"
+	ActionGitSyncPruned           Action = "git.sync.pruned"
+	ActionGitPushReceived         Action = "git.push.received"
 )
 
 // Resource identifies the target of an audit event.

--- a/packages/engine/internal/cli/repos.go
+++ b/packages/engine/internal/cli/repos.go
@@ -33,6 +33,8 @@ background poller run. Auth material is stored in a "git" credential type
 	cmd.AddCommand(newReposStatusCommand())
 	cmd.AddCommand(newReposRemoveCommand())
 	cmd.AddCommand(newReposSyncCommand())
+	cmd.AddCommand(newReposPlanCommand())
+	cmd.AddCommand(newReposApplyCommand())
 	return cmd
 }
 
@@ -290,25 +292,7 @@ of cloning (useful for tests and CI-driven deployments).`,
 			if err != nil {
 				return err
 			}
-			var driver sync.Driver
-			if fromDir != "" {
-				driver = &sync.NoopDriver{BasePath: fromDir}
-			} else {
-				var secretResolver *secret.Resolver
-				if cfg := config.FromContext(cmd.Context()); cfg != nil && cfg.Encryption.Key != "" {
-					encryptor, encErr := secret.NewEncryptor(cfg.Encryption.Key)
-					if encErr != nil {
-						return fmt.Errorf("configuring encryption for git sync: %w", encErr)
-					}
-					secretResolver = &secret.Resolver{
-						Store: &secret.Store{DB: store.DB, Encryptor: encryptor},
-					}
-				}
-				driver = &sync.GoGitDriver{
-					BasePath: filepath.Join(os.TempDir(), "mantle-repos"),
-					Auth:     sync.NewAuthResolver(cmd.Context(), secretResolver),
-				}
-			}
+			driver := buildSyncDriver(cmd, store, fromDir)
 			report, err := sync.SyncRepo(cmd.Context(), store.DB, store, r, driver)
 			if err != nil {
 				return fmt.Errorf("sync %q: %w", r.Name, err)
@@ -325,4 +309,102 @@ of cloning (useful for tests and CI-driven deployments).`,
 	}
 	cmd.Flags().StringVar(&fromDir, "from-dir", "", "Path to an already-cloned repo directory (skips git pull; useful for CI pipelines or local testing)")
 	return cmd
+}
+
+func newReposPlanCommand() *cobra.Command {
+	var fromDir string
+	cmd := &cobra.Command{
+		Use:   "plan <name>",
+		Short: "Dry-run: show what a sync would change",
+		Long: `Plans a sync without writing anything: pulls the repo, discovers files,
+and classifies each as "would apply" (new or changed) or "unchanged". Use
+before mantle repos apply to verify pending changes on auto_apply:false repos.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, cleanup, err := newRepoStore(cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			r, err := store.Get(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			driver := buildSyncDriver(cmd, store, fromDir)
+			report, err := sync.PlanRepo(cmd.Context(), store.DB, r, driver)
+			if err != nil {
+				return fmt.Errorf("plan %q: %w", r.Name, err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"Plan for %s — would apply=%d unchanged=%d failures=%d (SHA %s)\n",
+				r.Name, report.Applied, report.Unchanged, len(report.Failures), report.SHA)
+			for _, f := range report.Failures {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  FAIL %s: %s\n", f.RelPath, f.Err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&fromDir, "from-dir", "", "Path to an already-cloned repo directory (skips git pull; useful for CI pipelines or local testing)")
+	return cmd
+}
+
+func newReposApplyCommand() *cobra.Command {
+	var fromDir string
+	cmd := &cobra.Command{
+		Use:   "apply <name>",
+		Short: "Manually sync a repo (for auto_apply:false)",
+		Long: `Runs one sync pass for the named repo. Works regardless of auto_apply
+setting — useful when auto_apply is false and you want explicit control
+over when workflow YAML lands in Mantle.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, cleanup, err := newRepoStore(cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			r, err := store.Get(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			driver := buildSyncDriver(cmd, store, fromDir)
+			report, err := sync.SyncRepo(cmd.Context(), store.DB, store, r, driver)
+			if err != nil {
+				return fmt.Errorf("apply %q: %w", r.Name, err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"Applied %s — applied=%d unchanged=%d failures=%d (SHA %s)\n",
+				r.Name, report.Applied, report.Unchanged, len(report.Failures), report.SHA)
+			for _, f := range report.Failures {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  FAIL %s: %s\n", f.RelPath, f.Err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&fromDir, "from-dir", "", "Path to an already-cloned repo directory (skips git pull; useful for CI pipelines or local testing)")
+	return cmd
+}
+
+// buildSyncDriver picks NoopDriver when --from-dir is set, otherwise a
+// GoGitDriver rooted at a temp path. Extracted from newReposSyncCommand so
+// plan and apply don't duplicate the branching logic.
+func buildSyncDriver(cmd *cobra.Command, store *repo.Store, fromDir string) sync.Driver {
+	if fromDir != "" {
+		return &sync.NoopDriver{BasePath: fromDir}
+	}
+	var secretResolver *secret.Resolver
+	if cfg := config.FromContext(cmd.Context()); cfg != nil && cfg.Encryption.Key != "" {
+		encryptor, encErr := secret.NewEncryptor(cfg.Encryption.Key)
+		if encErr == nil {
+			secretResolver = &secret.Resolver{
+				Store: &secret.Store{DB: store.DB, Encryptor: encryptor},
+			}
+		}
+	}
+	return &sync.GoGitDriver{
+		BasePath: filepath.Join(os.TempDir(), "mantle-repos"),
+		Auth:     sync.NewAuthResolver(cmd.Context(), secretResolver),
+	}
 }

--- a/packages/engine/internal/cli/repos.go
+++ b/packages/engine/internal/cli/repos.go
@@ -28,6 +28,7 @@ background poller run. Auth material is stored in a "git" credential type
 (` + "`mantle secrets create --type git`" + `) and referenced here by name.`,
 	}
 	cmd.AddCommand(newReposAddCommand())
+	cmd.AddCommand(newReposUpdateCommand())
 	cmd.AddCommand(newReposListCommand())
 	cmd.AddCommand(newReposStatusCommand())
 	cmd.AddCommand(newReposRemoveCommand())
@@ -226,6 +227,46 @@ state, and timestamp of the last successful sync.`,
 			return w.Flush()
 		},
 	}
+}
+
+func newReposUpdateCommand() *cobra.Command {
+	var branch, path, pollInterval, credential string
+	var autoApply, prune, enabled bool
+
+	cmd := &cobra.Command{
+		Use:   "update <name>",
+		Short: "Update a registered repo's mutable fields",
+		Long: `Replaces the branch, path, poll-interval, credential, auto-apply, prune,
+and enabled flags on an existing repo. URL and name are immutable — to
+change them, delete and recreate.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, cleanup, err := newRepoStore(cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			r, err := store.Update(cmd.Context(), args[0], repo.UpdateParams{
+				Branch: branch, Path: path, PollInterval: pollInterval,
+				Credential: credential, AutoApply: autoApply, Prune: prune, Enabled: enabled,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated repo %q\n", r.Name)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&branch, "branch", "main", "Branch to sync")
+	cmd.Flags().StringVar(&path, "path", "/", "Subdirectory inside the repo to scan")
+	cmd.Flags().StringVar(&pollInterval, "poll-interval", "60s", "Interval between syncs")
+	cmd.Flags().StringVar(&credential, "credential", "", "Git credential name (required)")
+	cmd.Flags().BoolVar(&autoApply, "auto-apply", true, "Automatically apply changes")
+	cmd.Flags().BoolVar(&prune, "prune", true, "Disable workflows deleted from the repo")
+	cmd.Flags().BoolVar(&enabled, "enabled", true, "Whether the repo is active")
+	_ = cmd.MarkFlagRequired("credential")
+	return cmd
 }
 
 func newReposSyncCommand() *cobra.Command {

--- a/packages/engine/internal/cli/repos.go
+++ b/packages/engine/internal/cli/repos.go
@@ -168,7 +168,16 @@ command only stops future syncs. Requires --yes to confirm.`,
 			}
 			defer cleanup()
 
-			if err := store.Delete(cmd.Context(), args[0]); err != nil {
+			cfg := config.FromContext(cmd.Context())
+			cloneBase := ""
+			if cfg != nil {
+				artifactBase := cfg.Storage.Path
+				if artifactBase == "" {
+					artifactBase = filepath.Join(os.TempDir(), "mantle-artifacts")
+				}
+				cloneBase = filepath.Join(artifactBase, "git")
+			}
+			if err := store.Delete(cmd.Context(), args[0], cloneBase); err != nil {
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Removed repo %q\n", args[0])

--- a/packages/engine/internal/cli/repos.go
+++ b/packages/engine/internal/cli/repos.go
@@ -23,9 +23,11 @@ func newReposCommand() *cobra.Command {
 		Short: "Manage GitOps workflow source repositories",
 		Long: `Registers GitOps source repositories whose workflow YAML definitions are
 synced into this Mantle instance. This command manages the registry; use
-` + "`mantle repos sync`" + ` for on-demand syncs, or start ` + "`mantle serve`" + ` to let the
-background poller run. Auth material is stored in a "git" credential type
-(` + "`mantle secrets create --type git`" + `) and referenced here by name.`,
+` + "`mantle repos sync`" + ` for ad-hoc syncs, ` + "`mantle repos plan`" + ` to preview changes
+without writing, ` + "`mantle repos apply`" + ` for manual control over auto_apply:false
+repos, or start ` + "`mantle serve`" + ` to let the background poller run. Auth material
+is stored in a "git" credential type (` + "`mantle secrets create --type git`" + `) and
+referenced here by name.`,
 	}
 	cmd.AddCommand(newReposAddCommand())
 	cmd.AddCommand(newReposUpdateCommand())
@@ -54,7 +56,7 @@ func newRepoStore(cmd *cobra.Command) (*repo.Store, func(), error) {
 }
 
 func newReposAddCommand() *cobra.Command {
-	var url, branch, path, pollInterval, credential string
+	var url, branch, path, pollInterval, credential, webhookSecret string
 	var autoApply, prune bool
 
 	cmd := &cobra.Command{
@@ -73,14 +75,15 @@ credential must already exist and be of type "git".`,
 			defer cleanup()
 
 			r, err := store.Create(cmd.Context(), repo.CreateParams{
-				Name:         args[0],
-				URL:          url,
-				Branch:       branch,
-				Path:         path,
-				PollInterval: pollInterval,
-				Credential:   credential,
-				AutoApply:    autoApply,
-				Prune:        prune,
+				Name:          args[0],
+				URL:           url,
+				Branch:        branch,
+				Path:          path,
+				PollInterval:  pollInterval,
+				Credential:    credential,
+				AutoApply:     autoApply,
+				Prune:         prune,
+				WebhookSecret: webhookSecret,
 			})
 			if err != nil {
 				return err
@@ -97,6 +100,8 @@ credential must already exist and be of type "git".`,
 	cmd.Flags().StringVar(&credential, "credential", "", "Git credential name (required)")
 	cmd.Flags().BoolVar(&autoApply, "auto-apply", true, "Automatically apply changes (false = plan-only)")
 	cmd.Flags().BoolVar(&prune, "prune", true, "When true, workflows deleted from the repo are disabled in Mantle")
+	cmd.Flags().StringVar(&webhookSecret, "webhook-secret", "",
+		"HMAC secret for push webhook verification (empty = no verification)")
 	_ = cmd.MarkFlagRequired("url")
 	_ = cmd.MarkFlagRequired("credential")
 
@@ -232,7 +237,7 @@ state, and timestamp of the last successful sync.`,
 }
 
 func newReposUpdateCommand() *cobra.Command {
-	var branch, path, pollInterval, credential string
+	var branch, path, pollInterval, credential, webhookSecret string
 	var autoApply, prune, enabled bool
 
 	cmd := &cobra.Command{
@@ -240,7 +245,9 @@ func newReposUpdateCommand() *cobra.Command {
 		Short: "Update a registered repo's mutable fields",
 		Long: `Replaces the branch, path, poll-interval, credential, auto-apply, prune,
 and enabled flags on an existing repo. URL and name are immutable — to
-change them, delete and recreate.`,
+change them, delete and recreate.
+All flags must be provided — update replaces the full set of mutable fields.
+Omitting a flag resets that field to its default value.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store, cleanup, err := newRepoStore(cmd)
@@ -252,6 +259,7 @@ change them, delete and recreate.`,
 			r, err := store.Update(cmd.Context(), args[0], repo.UpdateParams{
 				Branch: branch, Path: path, PollInterval: pollInterval,
 				Credential: credential, AutoApply: autoApply, Prune: prune, Enabled: enabled,
+				WebhookSecret: webhookSecret,
 			})
 			if err != nil {
 				return err
@@ -267,6 +275,8 @@ change them, delete and recreate.`,
 	cmd.Flags().BoolVar(&autoApply, "auto-apply", true, "Automatically apply changes")
 	cmd.Flags().BoolVar(&prune, "prune", true, "Disable workflows deleted from the repo")
 	cmd.Flags().BoolVar(&enabled, "enabled", true, "Whether the repo is active")
+	cmd.Flags().StringVar(&webhookSecret, "webhook-secret", "",
+		"HMAC secret for push webhook verification (empty = no verification)")
 	_ = cmd.MarkFlagRequired("credential")
 	return cmd
 }
@@ -318,7 +328,7 @@ func newReposPlanCommand() *cobra.Command {
 		Short: "Dry-run: show what a sync would change",
 		Long: `Plans a sync without writing anything: pulls the repo, discovers files,
 and classifies each as "would apply" (new or changed) or "unchanged". Use
-before mantle repos apply to verify pending changes on auto_apply:false repos.`,
+before mantle repos apply to preview pending changes before they land.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store, cleanup, err := newRepoStore(cmd)
@@ -353,10 +363,11 @@ func newReposApplyCommand() *cobra.Command {
 	var fromDir string
 	cmd := &cobra.Command{
 		Use:   "apply <name>",
-		Short: "Manually sync a repo (for auto_apply:false)",
-		Long: `Runs one sync pass for the named repo. Works regardless of auto_apply
-setting — useful when auto_apply is false and you want explicit control
-over when workflow YAML lands in Mantle.`,
+		Short: "Apply pending workflow changes from a repo",
+		Long: `Runs one sync pass for the named repo. Useful when auto_apply is false and you
+want explicit control over when workflow YAML lands in Mantle. Also works for
+auto_apply:true repos when you want to apply immediately without waiting for
+the next poll.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store, cleanup, err := newRepoStore(cmd)

--- a/packages/engine/internal/cli/repos_test.go
+++ b/packages/engine/internal/cli/repos_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -19,7 +20,7 @@ import (
 // reposCtx spins up a Postgres container, runs migrations, and returns a
 // *config.Config with the DatabaseConfig attached. Callers pass the database
 // URL via --database-url flags; the config is used only to read that URL.
-func reposCtx(t *testing.T) *config.Config {
+func reposCtx(t *testing.T) (context.Context, *config.Config) {
 	t.Helper()
 	bg := t.Context()
 	pgContainer, err := postgres.Run(bg,
@@ -53,7 +54,7 @@ func reposCtx(t *testing.T) *config.Config {
 	if err := db.Migrate(bg, conn); err != nil {
 		t.Fatalf("db.Migrate: %v", err)
 	}
-	return &config.Config{Database: dbCfg}
+	return bg, &config.Config{Database: dbCfg}
 }
 
 // seedRepo registers a single repo via the add command, failing the test on
@@ -74,7 +75,7 @@ func seedRepo(t *testing.T, cfg *config.Config, name string) {
 }
 
 func TestReposAdd_PersistsRepo(t *testing.T) {
-	cfg := reposCtx(t)
+	_, cfg := reposCtx(t)
 	root := NewRootCommand()
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
@@ -132,7 +133,7 @@ func TestReposAdd_WebhookSecretStoredNotPrinted(t *testing.T) {
 }
 
 func TestReposList_ShowsRegisteredRepos(t *testing.T) {
-	cfg := reposCtx(t)
+	_, cfg := reposCtx(t)
 	seedRepo(t, cfg, "acme")
 
 	root := NewRootCommand()
@@ -150,7 +151,7 @@ func TestReposList_ShowsRegisteredRepos(t *testing.T) {
 }
 
 func TestReposList_EmptyState(t *testing.T) {
-	cfg := reposCtx(t)
+	_, cfg := reposCtx(t)
 	root := NewRootCommand()
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
@@ -165,7 +166,7 @@ func TestReposList_EmptyState(t *testing.T) {
 }
 
 func TestReposStatus_ShowsDetails(t *testing.T) {
-	cfg := reposCtx(t)
+	_, cfg := reposCtx(t)
 	seedRepo(t, cfg, "acme")
 
 	root := NewRootCommand()
@@ -185,7 +186,7 @@ func TestReposStatus_ShowsDetails(t *testing.T) {
 }
 
 func TestReposRemove_RequiresYesFlag(t *testing.T) {
-	cfg := reposCtx(t)
+	_, cfg := reposCtx(t)
 	seedRepo(t, cfg, "acme")
 
 	root := NewRootCommand()
@@ -199,7 +200,7 @@ func TestReposRemove_RequiresYesFlag(t *testing.T) {
 }
 
 func TestReposRemove_DeletesRow(t *testing.T) {
-	cfg := reposCtx(t)
+	_, cfg := reposCtx(t)
 	seedRepo(t, cfg, "acme")
 
 	root := NewRootCommand()
@@ -315,7 +316,7 @@ func TestReposApply_PrintsSummary(t *testing.T) {
 }
 
 func TestReposSync_UsesNoopDriverWithFromDir(t *testing.T) {
-	cfg := reposCtx(t)
+	_, cfg := reposCtx(t)
 	// Seed a repo.
 	{
 		root := NewRootCommand()

--- a/packages/engine/internal/cli/repos_test.go
+++ b/packages/engine/internal/cli/repos_test.go
@@ -175,6 +175,41 @@ func TestReposRemove_DeletesRow(t *testing.T) {
 	}
 }
 
+func TestReposUpdate_ReplacesMutableFields(t *testing.T) {
+	_, cfg := reposCtx(t)
+	// Seed.
+	{
+		root := NewRootCommand()
+		var seedStderr bytes.Buffer
+		root.SetErr(&seedStderr)
+		root.SetArgs([]string{"repos", "add", "acme",
+			"--url", "https://example.com/a.git",
+			"--credential", "pat-v1",
+			"--database-url", cfg.Database.URL,
+		})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("seed add: %v\nstderr: %s", err, seedStderr.String())
+		}
+	}
+
+	root := NewRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"repos", "update", "acme",
+		"--branch", "release",
+		"--credential", "pat-v2",
+		"--auto-apply=false",
+		"--database-url", cfg.Database.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("update: %v\nstderr: %s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Updated repo \"acme\"") {
+		t.Errorf("unexpected stdout: %q", stdout.String())
+	}
+}
+
 func TestReposSync_UsesNoopDriverWithFromDir(t *testing.T) {
 	cfg := reposCtx(t)
 	// Seed a repo.

--- a/packages/engine/internal/cli/repos_test.go
+++ b/packages/engine/internal/cli/repos_test.go
@@ -210,6 +210,70 @@ func TestReposUpdate_ReplacesMutableFields(t *testing.T) {
 	}
 }
 
+func TestReposPlan_PrintsSummary(t *testing.T) {
+	_, cfg := reposCtx(t)
+	{
+		root := NewRootCommand()
+		var seedStderr bytes.Buffer
+		root.SetErr(&seedStderr)
+		root.SetArgs([]string{"repos", "add", "acme",
+			"--url", "https://example.com/a.git",
+			"--credential", "pat",
+			"--database-url", cfg.Database.URL,
+		})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("seed add: %v", err)
+		}
+	}
+	fixture := t.TempDir()
+	root := NewRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"repos", "plan", "acme",
+		"--from-dir", fixture,
+		"--database-url", cfg.Database.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("plan: %v\nstderr: %s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Plan for acme") {
+		t.Errorf("expected 'Plan for acme' in stdout, got %q", stdout.String())
+	}
+}
+
+func TestReposApply_PrintsSummary(t *testing.T) {
+	_, cfg := reposCtx(t)
+	{
+		root := NewRootCommand()
+		var seedStderr bytes.Buffer
+		root.SetErr(&seedStderr)
+		root.SetArgs([]string{"repos", "add", "acme",
+			"--url", "https://example.com/a.git",
+			"--credential", "pat",
+			"--database-url", cfg.Database.URL,
+		})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("seed add: %v", err)
+		}
+	}
+	fixture := t.TempDir()
+	root := NewRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"repos", "apply", "acme",
+		"--from-dir", fixture,
+		"--database-url", cfg.Database.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("apply: %v\nstderr: %s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Applied acme") {
+		t.Errorf("expected 'Applied acme' in stdout, got %q", stdout.String())
+	}
+}
+
 func TestReposSync_UsesNoopDriverWithFromDir(t *testing.T) {
 	cfg := reposCtx(t)
 	// Seed a repo.

--- a/packages/engine/internal/cli/repos_test.go
+++ b/packages/engine/internal/cli/repos_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dvflw/mantle/internal/config"
 	"github.com/dvflw/mantle/internal/db"
 	"github.com/dvflw/mantle/internal/dbdefaults"
+	"github.com/dvflw/mantle/internal/repo"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -88,6 +89,45 @@ func TestReposAdd_PersistsRepo(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Added repo \"acme\"") {
 		t.Errorf("unexpected stdout: %q", stdout.String())
+	}
+}
+
+func TestReposAdd_WebhookSecretStoredNotPrinted(t *testing.T) {
+	ctx, cfg := reposCtx(t)
+	root := NewRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"repos", "add", "acme-webhook",
+		"--url", "https://github.com/acme/workflows.git",
+		"--credential", "github-pat",
+		"--webhook-secret", "topsecret",
+		"--database-url", cfg.Database.URL,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v\nstderr: %s", err, stderr.String())
+	}
+	out := stdout.String()
+	// Secret must NOT appear in CLI output.
+	if strings.Contains(out, "topsecret") {
+		t.Errorf("webhook secret leaked to stdout: %q", out)
+	}
+	if !strings.Contains(out, "Added repo \"acme-webhook\"") {
+		t.Errorf("unexpected stdout: %q", out)
+	}
+	// Verify the secret was actually stored by reading it back via store.
+	conn, err := db.Open(cfg.Database)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer conn.Close()
+	store := &repo.Store{DB: conn, Actor: "test"}
+	got, err := store.Get(ctx, "acme-webhook")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.WebhookSecret != "topsecret" {
+		t.Errorf("WebhookSecret: got %q, want %q", got.WebhookSecret, "topsecret")
 	}
 }
 

--- a/packages/engine/internal/cli/serve.go
+++ b/packages/engine/internal/cli/serve.go
@@ -165,15 +165,20 @@ func newServeCommand() *cobra.Command {
 					Store: &secret.Store{DB: database, Encryptor: encryptor},
 				}
 			}
+			gitDriver := &reposync.GoGitDriver{
+				BasePath: filepath.Join(artifactBase, "git"),
+				Auth:     reposync.NewAuthResolver(ctx, secretResolver),
+			}
 			poller := &reposync.Poller{
-				DB:    database,
-				Store: repoStore,
-				Driver: &reposync.GoGitDriver{
-					BasePath: filepath.Join(artifactBase, "git"),
-					Auth:     reposync.NewAuthResolver(ctx, secretResolver),
-				},
+				DB:     database,
+				Store:  repoStore,
+				Driver: gitDriver,
 			}
 			go poller.Run(ctx)
+
+			// Wire git webhook handler into the server.
+			srv.RepoStore = repoStore
+			srv.GitDriver = gitDriver
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Mantle server starting on %s\n", cfg.API.Address)
 			return srv.Start(ctx)

--- a/packages/engine/internal/db/migrations/020_git_sync_prune.sql
+++ b/packages/engine/internal/db/migrations/020_git_sync_prune.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+-- 020_git_sync_prune: adds the columns Plan C needs to implement prune
+-- behavior for GitOps sync (issue #16).
+--
+-- workflow_definitions.disabled_at marks a version as inactive without
+-- losing history. The sync engine sets it when a repo is pruning and
+-- the workflow's source file has been removed upstream; clears it when
+-- the file reappears.
+--
+-- git_repo_workflows tracks which workflows each repo "owns" so prune
+-- does not accidentally disable workflows that were applied through
+-- the CLI or from a different repo.
+ALTER TABLE workflow_definitions
+    ADD COLUMN disabled_at TIMESTAMPTZ;
+
+CREATE INDEX idx_workflow_definitions_disabled
+    ON workflow_definitions(disabled_at)
+    WHERE disabled_at IS NOT NULL;
+
+CREATE TABLE git_repo_workflows (
+    repo_id UUID NOT NULL REFERENCES git_repos(id) ON DELETE CASCADE,
+    workflow_name TEXT NOT NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (repo_id, workflow_name)
+);
+
+CREATE INDEX idx_git_repo_workflows_repo ON git_repo_workflows(repo_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS git_repo_workflows;
+DROP INDEX IF EXISTS idx_workflow_definitions_disabled;
+ALTER TABLE workflow_definitions DROP COLUMN IF EXISTS disabled_at;

--- a/packages/engine/internal/db/migrations/021_git_repo_webhook_secret.sql
+++ b/packages/engine/internal/db/migrations/021_git_repo_webhook_secret.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- 021_git_repo_webhook_secret: adds the webhook_secret column to git_repos.
+-- Stores the HMAC-SHA256 shared secret used to verify inbound push webhooks
+-- from git providers (GitHub, GitLab, Gitea). NULL means no HMAC verification.
+-- The value is sensitive: the CLI never renders it and audit metadata omits it.
+ALTER TABLE git_repos
+    ADD COLUMN webhook_secret TEXT;
+
+-- +goose Down
+ALTER TABLE git_repos DROP COLUMN IF EXISTS webhook_secret;

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -383,16 +383,16 @@ func (s *Store) Get(ctx context.Context, name string) (*Repo, error) {
 
 	var r Repo
 	var lastSyncAt sql.NullTime
-	var lastSyncSHA, lastSyncError sql.NullString
+	var lastSyncSHA, lastSyncError, webhookSecret sql.NullString
 	err := s.DB.QueryRowContext(ctx,
 		`SELECT id, name, url, branch, path, poll_interval, credential,
 		        auto_apply, prune, enabled, last_sync_sha, last_sync_at,
-		        last_sync_error, created_at, updated_at
+		        last_sync_error, webhook_secret, created_at, updated_at
 		 FROM git_repos WHERE name = $1 AND team_id = $2`,
 		name, teamID,
 	).Scan(&r.ID, &r.Name, &r.URL, &r.Branch, &r.Path, &r.PollInterval,
 		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled,
-		&lastSyncSHA, &lastSyncAt, &lastSyncError,
+		&lastSyncSHA, &lastSyncAt, &lastSyncError, &webhookSecret,
 		&r.CreatedAt, &r.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("%w: %q", ErrNotFound, name)
@@ -409,6 +409,9 @@ func (s *Store) Get(ctx context.Context, name string) (*Repo, error) {
 	}
 	if lastSyncError.Valid {
 		r.LastSyncError = lastSyncError.String
+	}
+	if webhookSecret.Valid {
+		r.WebhookSecret = webhookSecret.String
 	}
 	return &r, nil
 }

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -5,7 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/dvflw/mantle/internal/audit"
@@ -235,7 +238,13 @@ func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo,
 
 // Delete removes a repo by name and emits a repo.removed audit event in
 // the same transaction. Returns ErrNotFound when no row matches.
-func (s *Store) Delete(ctx context.Context, name string) error {
+//
+// If cloneBasePath is non-empty, Delete also removes the cloned working
+// tree at filepath.Join(cloneBasePath, repoID) after the DB transaction
+// commits. Filesystem failures are logged but do not fail the call — the
+// DB row is already gone, and an orphan directory is better than an orphan
+// row.
+func (s *Store) Delete(ctx context.Context, name, cloneBasePath string) error {
 	teamID := auth.TeamIDFromContext(ctx)
 
 	tx, err := s.DB.BeginTx(ctx, nil)
@@ -268,6 +277,14 @@ func (s *Store) Delete(ctx context.Context, name string) error {
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("committing repo delete: %w", err)
+	}
+
+	if cloneBasePath != "" {
+		cloneDir := filepath.Join(cloneBasePath, deletedID)
+		if err := os.RemoveAll(cloneDir); err != nil {
+			slog.Warn("repo delete: failed to remove cloned working tree",
+				"clone_dir", cloneDir, "err", err)
+		}
 	}
 	return nil
 }

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -38,14 +38,15 @@ var ErrNotFound = errors.New("repo not found")
 // Fields with empty defaults (Branch, Path, PollInterval) are filled
 // in by the caller using the same defaults the `git_repos` table uses.
 type CreateParams struct {
-	Name         string
-	URL          string
-	Branch       string
-	Path         string
-	PollInterval string
-	Credential   string
-	AutoApply    bool
-	Prune        bool
+	Name          string
+	URL           string
+	Branch        string
+	Path          string
+	PollInterval  string
+	Credential    string
+	AutoApply     bool
+	Prune         bool
+	WebhookSecret string // empty → NULL (no HMAC verification)
 }
 
 // Create inserts a new repo row and emits a repo.added audit event.
@@ -68,6 +69,13 @@ func (s *Store) Create(ctx context.Context, p CreateParams) (*Repo, error) {
 
 	teamID := auth.TeamIDFromContext(ctx)
 
+	var webhookSecret any
+	if p.WebhookSecret != "" {
+		webhookSecret = p.WebhookSecret
+	} else {
+		webhookSecret = nil
+	}
+
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("starting transaction: %w", err)
@@ -75,19 +83,23 @@ func (s *Store) Create(ctx context.Context, p CreateParams) (*Repo, error) {
 	defer tx.Rollback() //nolint:errcheck
 
 	var r Repo
+	var returnedWebhookSecret sql.NullString
 	err = tx.QueryRowContext(ctx,
 		`INSERT INTO git_repos
-		 (team_id, name, url, branch, path, poll_interval, credential, auto_apply, prune)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 (team_id, name, url, branch, path, poll_interval, credential, auto_apply, prune, webhook_secret)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		 RETURNING id, name, url, branch, path, poll_interval, credential,
-		           auto_apply, prune, enabled, created_at, updated_at`,
+		           auto_apply, prune, enabled, webhook_secret, created_at, updated_at`,
 		teamID, p.Name, p.URL, p.Branch, p.Path, p.PollInterval, p.Credential,
-		p.AutoApply, p.Prune,
+		p.AutoApply, p.Prune, webhookSecret,
 	).Scan(&r.ID, &r.Name, &r.URL, &r.Branch, &r.Path, &r.PollInterval,
-		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled,
+		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled, &returnedWebhookSecret,
 		&r.CreatedAt, &r.UpdatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("creating repo %q: %w", p.Name, err)
+	}
+	if returnedWebhookSecret.Valid {
+		r.WebhookSecret = returnedWebhookSecret.String
 	}
 
 	if err := audit.EmitTx(ctx, tx, audit.Event{
@@ -155,13 +167,14 @@ func (s *Store) List(ctx context.Context) ([]Repo, error) {
 // intentionally omitted — changing either requires delete + recreate so
 // that audit history clearly reflects the identity change.
 type UpdateParams struct {
-	Branch       string
-	Path         string
-	PollInterval string
-	Credential   string
-	AutoApply    bool
-	Prune        bool
-	Enabled      bool
+	Branch        string
+	Path          string
+	PollInterval  string
+	Credential    string
+	AutoApply     bool
+	Prune         bool
+	Enabled       bool
+	WebhookSecret string // empty → NULL (no HMAC verification)
 }
 
 // Update replaces the mutable fields of a repo by name and emits a
@@ -178,6 +191,13 @@ func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo,
 
 	teamID := auth.TeamIDFromContext(ctx)
 
+	var updateWebhookSecret any
+	if p.WebhookSecret != "" {
+		updateWebhookSecret = p.WebhookSecret
+	} else {
+		updateWebhookSecret = nil
+	}
+
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("starting transaction: %w", err)
@@ -185,23 +205,19 @@ func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo,
 	defer tx.Rollback() //nolint:errcheck
 
 	var r Repo
-	var lastSyncAt sql.NullTime
-	var lastSyncSHA, lastSyncError sql.NullString
+	var updatedWebhookSecret sql.NullString
 	err = tx.QueryRowContext(ctx,
 		`UPDATE git_repos
-		 SET branch       = CASE WHEN $3 = '' THEN branch ELSE $3 END,
-		     path         = CASE WHEN $4 = '' THEN path   ELSE $4 END,
-		     poll_interval = $5, credential = $6,
-		     auto_apply = $7, prune = $8, enabled = $9, updated_at = NOW()
+		 SET branch = $3, path = $4, poll_interval = $5, credential = $6,
+		     auto_apply = $7, prune = $8, enabled = $9, webhook_secret = $10,
+		     updated_at = NOW()
 		 WHERE name = $1 AND team_id = $2
 		 RETURNING id, name, url, branch, path, poll_interval, credential,
-		           auto_apply, prune, enabled, last_sync_sha, last_sync_at,
-		           last_sync_error, created_at, updated_at`,
+		           auto_apply, prune, enabled, webhook_secret, created_at, updated_at`,
 		name, teamID, p.Branch, p.Path, p.PollInterval, p.Credential,
-		p.AutoApply, p.Prune, p.Enabled,
+		p.AutoApply, p.Prune, p.Enabled, updateWebhookSecret,
 	).Scan(&r.ID, &r.Name, &r.URL, &r.Branch, &r.Path, &r.PollInterval,
-		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled,
-		&lastSyncSHA, &lastSyncAt, &lastSyncError,
+		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled, &updatedWebhookSecret,
 		&r.CreatedAt, &r.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("%w: %q", ErrNotFound, name)
@@ -209,15 +225,8 @@ func (s *Store) Update(ctx context.Context, name string, p UpdateParams) (*Repo,
 	if err != nil {
 		return nil, fmt.Errorf("updating repo %q: %w", name, err)
 	}
-	if lastSyncSHA.Valid {
-		r.LastSyncSHA = lastSyncSHA.String
-	}
-	if lastSyncAt.Valid {
-		t := lastSyncAt.Time
-		r.LastSyncAt = &t
-	}
-	if lastSyncError.Valid {
-		r.LastSyncError = lastSyncError.String
+	if updatedWebhookSecret.Valid {
+		r.WebhookSecret = updatedWebhookSecret.String
 	}
 
 	if err := audit.EmitTx(ctx, tx, audit.Event{

--- a/packages/engine/internal/repo/store.go
+++ b/packages/engine/internal/repo/store.go
@@ -310,6 +310,46 @@ func validateURL(raw string) error {
 	return nil
 }
 
+// GetByID retrieves a repo by its UUID. Unlike Get, it does NOT filter
+// by team_id — the webhook receiver at /hooks/git/<id> must be able to
+// look up repos across any team because the URL carries the UUID and
+// no auth context. Returns ErrNotFound when no row matches.
+func (s *Store) GetByID(ctx context.Context, id string) (*Repo, error) {
+	var r Repo
+	var lastSyncAt sql.NullTime
+	var lastSyncSHA, lastSyncError, webhookSecret sql.NullString
+	err := s.DB.QueryRowContext(ctx,
+		`SELECT id, name, url, branch, path, poll_interval, credential,
+		        auto_apply, prune, enabled, last_sync_sha, last_sync_at,
+		        last_sync_error, webhook_secret, created_at, updated_at
+		 FROM git_repos WHERE id = $1`,
+		id,
+	).Scan(&r.ID, &r.Name, &r.URL, &r.Branch, &r.Path, &r.PollInterval,
+		&r.Credential, &r.AutoApply, &r.Prune, &r.Enabled,
+		&lastSyncSHA, &lastSyncAt, &lastSyncError, &webhookSecret,
+		&r.CreatedAt, &r.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %q", ErrNotFound, id)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying repo by id: %w", err)
+	}
+	if lastSyncSHA.Valid {
+		r.LastSyncSHA = lastSyncSHA.String
+	}
+	if lastSyncAt.Valid {
+		t := lastSyncAt.Time
+		r.LastSyncAt = &t
+	}
+	if lastSyncError.Valid {
+		r.LastSyncError = lastSyncError.String
+	}
+	if webhookSecret.Valid {
+		r.WebhookSecret = webhookSecret.String
+	}
+	return &r, nil
+}
+
 // Get retrieves a repo by name within the current team scope. Returns
 // ErrNotFound when no row matches.
 func (s *Store) Get(ctx context.Context, name string) (*Repo, error) {

--- a/packages/engine/internal/repo/store_test.go
+++ b/packages/engine/internal/repo/store_test.go
@@ -392,6 +392,45 @@ func TestStore_Delete_IgnoresMissingCloneDir(t *testing.T) {
 	}
 }
 
+func TestStore_Create_StoresWebhookSecret(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	r, err := store.Create(ctx, CreateParams{
+		Name: "with-secret", URL: "https://example.com/a.git", Branch: "main",
+		Path: "/", PollInterval: "60s", Credential: "pat",
+		WebhookSecret: "s3cr3t",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := store.GetByID(ctx, r.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.WebhookSecret != "s3cr3t" {
+		t.Errorf("WebhookSecret: got %q, want %q", got.WebhookSecret, "s3cr3t")
+	}
+}
+
+func TestStore_Create_NullWebhookSecretByDefault(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	r, err := store.Create(ctx, CreateParams{
+		Name: "no-secret", URL: "https://example.com/b.git", Branch: "main",
+		Path: "/", PollInterval: "60s", Credential: "pat",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := store.GetByID(ctx, r.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.WebhookSecret != "" {
+		t.Errorf("WebhookSecret should be empty, got %q", got.WebhookSecret)
+	}
+}
+
 func TestStore_UpdateSyncState_ClearsErrorWhenEmpty(t *testing.T) {
 	store := newTestStore(t)
 	ctx := defaultCtx()

--- a/packages/engine/internal/repo/store_test.go
+++ b/packages/engine/internal/repo/store_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -252,7 +253,7 @@ func TestStore_Delete_RemovesRow(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if err := store.Delete(ctx, "acme"); err != nil {
+	if err := store.Delete(ctx, "acme", ""); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 	if _, err := store.Get(ctx, "acme"); !errors.Is(err, ErrNotFound) {
@@ -263,7 +264,7 @@ func TestStore_Delete_RemovesRow(t *testing.T) {
 func TestStore_Delete_NotFound(t *testing.T) {
 	store := newTestStore(t)
 	ctx := defaultCtx()
-	if err := store.Delete(ctx, "nope"); !errors.Is(err, ErrNotFound) {
+	if err := store.Delete(ctx, "nope", ""); !errors.Is(err, ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
@@ -344,6 +345,50 @@ func TestStore_GetByID_NotFound(t *testing.T) {
 	_, err := store.GetByID(ctx, "00000000-0000-0000-0000-000000000000")
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestStore_Delete_RemovesClonedDirectory(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	r, err := store.Create(ctx, CreateParams{
+		Name: "acme", URL: "https://example.com/a.git", Branch: "main",
+		Path: "/", PollInterval: "60s", Credential: "pat",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	base := t.TempDir()
+	repoDir := filepath.Join(base, r.ID)
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "wf.yaml"), []byte("name: wf\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := store.Delete(ctx, "acme", base); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := os.Stat(repoDir); !os.IsNotExist(err) {
+		t.Errorf("clone dir should be gone: stat err = %v", err)
+	}
+}
+
+func TestStore_Delete_IgnoresMissingCloneDir(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	_, err := store.Create(ctx, CreateParams{
+		Name: "gone", URL: "https://example.com/a.git", Branch: "main",
+		Path: "/", PollInterval: "60s", Credential: "pat",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	base := t.TempDir()
+	// NOTE: don't create the subdir — Delete should still succeed.
+	if err := store.Delete(ctx, "gone", base); err != nil {
+		t.Fatalf("Delete: missing clone dir caused failure: %v", err)
 	}
 }
 

--- a/packages/engine/internal/repo/store_test.go
+++ b/packages/engine/internal/repo/store_test.go
@@ -322,6 +322,31 @@ func TestStore_UpdateSyncState_WritesFields(t *testing.T) {
 	}
 }
 
+func TestStore_GetByID_ReturnsRow(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	created, _ := store.Create(ctx, CreateParams{
+		Name: "acme", URL: "https://example.com/a.git", Branch: "main",
+		Path: "/", PollInterval: "60s", Credential: "pat",
+	})
+	got, err := store.GetByID(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Name != "acme" {
+		t.Errorf("Name: got %q, want acme", got.Name)
+	}
+}
+
+func TestStore_GetByID_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := defaultCtx()
+	_, err := store.GetByID(ctx, "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
 func TestStore_UpdateSyncState_ClearsErrorWhenEmpty(t *testing.T) {
 	store := newTestStore(t)
 	ctx := defaultCtx()

--- a/packages/engine/internal/repo/sync/engine.go
+++ b/packages/engine/internal/repo/sync/engine.go
@@ -185,6 +185,41 @@ func emit(ctx context.Context, database *sql.DB, e audit.Event) {
 	_ = tx.Commit()
 }
 
+// PlanRepo runs a dry-run sync: pulls the repo, discovers files, and
+// classifies each as "would apply" (new or changed) or "unchanged"
+// without writing to the DB. Returns a Report with the same shape as
+// SyncRepo's, so CLI output and tests stay consistent. No audit
+// events fire — planning is a read-only operation.
+func PlanRepo(ctx context.Context, database *sql.DB, r *repo.Repo, driver Driver) (*Report, error) {
+	pull, err := driver.Pull(ctx, r)
+	if err != nil {
+		return nil, fmt.Errorf("driver pull: %w", err)
+	}
+	files, err := Discover(pull.LocalPath, r.Path)
+	if err != nil {
+		return nil, fmt.Errorf("discover: %w", err)
+	}
+	report := &Report{SHA: pull.SHA}
+	for _, f := range files {
+		parsed, parseErr := workflow.ParseBytes(f.Bytes)
+		if parseErr != nil {
+			report.Failures = append(report.Failures, FileResult{RelPath: f.RelPath, Err: parseErr.Error()})
+			continue
+		}
+		existingHash, hashErr := workflow.GetLatestHash(ctx, database, parsed.Workflow.Name)
+		if hashErr != nil {
+			report.Failures = append(report.Failures, FileResult{RelPath: f.RelPath, Err: hashErr.Error()})
+			continue
+		}
+		if existingHash == f.Hash {
+			report.Unchanged++
+		} else {
+			report.Applied++ // semantically "would apply"
+		}
+	}
+	return report, nil
+}
+
 // summarizeFailures joins up to three failure messages into a single
 // string suitable for last_sync_error. Audit events carry the full
 // detail; this column is for at-a-glance CLI output.

--- a/packages/engine/internal/repo/sync/engine.go
+++ b/packages/engine/internal/repo/sync/engine.go
@@ -50,7 +50,7 @@ func SyncRepo(ctx context.Context, database *sql.DB, store *repo.Store, r *repo.
 
 	pull, err := driver.Pull(ctx, r)
 	if err != nil {
-		_ = store.UpdateSyncState(ctx, r.ID, "", fmt.Sprintf("pull failed: %v", err))
+		_ = store.UpdateSyncState(ctx, r.ID, "", sanitizeURL(fmt.Sprintf("pull failed: %v", err)))
 		emit(ctx, database, audit.Event{
 			Timestamp: time.Now(),
 			Actor:     "sync",
@@ -64,7 +64,7 @@ func SyncRepo(ctx context.Context, database *sql.DB, store *repo.Store, r *repo.
 
 	files, err := Discover(pull.LocalPath, r.Path)
 	if err != nil {
-		_ = store.UpdateSyncState(ctx, r.ID, pull.SHA, fmt.Sprintf("discover failed: %v", err))
+		_ = store.UpdateSyncState(ctx, r.ID, pull.SHA, sanitizeURL(fmt.Sprintf("discover failed: %v", err)))
 		emit(ctx, database, audit.Event{
 			Timestamp: time.Now(),
 			Actor:     "sync",
@@ -149,7 +149,7 @@ func SyncRepo(ctx context.Context, database *sql.DB, store *repo.Store, r *repo.
 
 	errSummary := ""
 	if len(report.Failures) > 0 {
-		errSummary = summarizeFailures(report.Failures)
+		errSummary = sanitizeURL(summarizeFailures(report.Failures))
 	}
 	_ = store.UpdateSyncState(ctx, r.ID, pull.SHA, errSummary)
 

--- a/packages/engine/internal/repo/sync/engine.go
+++ b/packages/engine/internal/repo/sync/engine.go
@@ -19,6 +19,7 @@ type Report struct {
 	Applied   int
 	Unchanged int
 	Failures  []FileResult
+	Pruned    int
 }
 
 // FileResult captures a per-file failure so operators can trace which
@@ -75,6 +76,14 @@ func SyncRepo(ctx context.Context, database *sql.DB, store *repo.Store, r *repo.
 		return nil, fmt.Errorf("discover: %w", err)
 	}
 
+	// Capture syncStart from the DB clock so it's in the same domain as
+	// the last_seen_at timestamps written by RecordSeen. Using Go's
+	// time.Now() risks a mismatch if the DB clock drifts relative to the
+	// host, which would cause either over-pruning or under-pruning.
+	var syncStart time.Time
+	if err := database.QueryRowContext(ctx, `SELECT NOW()`).Scan(&syncStart); err != nil {
+		syncStart = time.Now() // fall back to host clock if the query fails
+	}
 	report := &Report{SHA: pull.SHA}
 	for _, f := range files {
 		parseResult, parseErr := workflow.ParseBytes(f.Bytes)
@@ -103,10 +112,38 @@ func SyncRepo(ctx context.Context, database *sql.DB, store *repo.Store, r *repo.
 			})
 			continue
 		}
+		if recordErr := RecordSeen(ctx, database, r.ID, parseResult.Workflow.Name); recordErr != nil {
+			report.Failures = append(report.Failures, FileResult{RelPath: f.RelPath, Err: recordErr.Error()})
+			continue
+		}
+		// Re-enable if this workflow was previously pruned. Errors are
+		// non-fatal — surfacing them would require restructuring the loop;
+		// they are visible via the workflow.* audit events if re-enable
+		// itself fails.
+		_ = workflow.Reenable(ctx, database, parseResult.Workflow.Name)
 		if version == 0 {
 			report.Unchanged++
 		} else {
 			report.Applied++
+		}
+	}
+
+	if r.Prune {
+		stale, listErr := ListStale(ctx, database, r.ID, syncStart)
+		if listErr == nil {
+			for _, name := range stale {
+				_ = workflow.Disable(ctx, database, name)
+				emit(ctx, database, audit.Event{
+					Timestamp: time.Now(),
+					Actor:     "sync",
+					Action:    audit.ActionGitSyncPruned,
+					Resource:  audit.Resource{Type: "git_repo", ID: r.ID},
+					TeamID:    teamID,
+					Metadata:  map[string]string{"name": r.Name, "workflow": name},
+				})
+			}
+			_ = RemoveSeenRecords(ctx, database, r.ID, stale)
+			report.Pruned = len(stale)
 		}
 	}
 
@@ -128,6 +165,7 @@ func SyncRepo(ctx context.Context, database *sql.DB, store *repo.Store, r *repo.
 			"applied":   fmt.Sprintf("%d", report.Applied),
 			"unchanged": fmt.Sprintf("%d", report.Unchanged),
 			"failures":  fmt.Sprintf("%d", len(report.Failures)),
+			"pruned":    fmt.Sprintf("%d", report.Pruned),
 		},
 	})
 	return report, nil

--- a/packages/engine/internal/repo/sync/engine.go
+++ b/packages/engine/internal/repo/sync/engine.go
@@ -57,7 +57,7 @@ func SyncRepo(ctx context.Context, database *sql.DB, store *repo.Store, r *repo.
 			Action:    audit.ActionGitSyncFailed,
 			Resource:  audit.Resource{Type: "git_repo", ID: r.ID},
 			TeamID:    teamID,
-			Metadata:  map[string]string{"name": r.Name, "error": err.Error()},
+			Metadata:  map[string]string{"name": r.Name, "error": sanitizeURL(err.Error())},
 		})
 		return nil, fmt.Errorf("driver pull: %w", err)
 	}
@@ -71,7 +71,7 @@ func SyncRepo(ctx context.Context, database *sql.DB, store *repo.Store, r *repo.
 			Action:    audit.ActionGitSyncFailed,
 			Resource:  audit.Resource{Type: "git_repo", ID: r.ID},
 			TeamID:    teamID,
-			Metadata:  map[string]string{"name": r.Name, "error": err.Error()},
+			Metadata:  map[string]string{"name": r.Name, "error": sanitizeURL(err.Error())},
 		})
 		return nil, fmt.Errorf("discover: %w", err)
 	}
@@ -95,7 +95,7 @@ func SyncRepo(ctx context.Context, database *sql.DB, store *repo.Store, r *repo.
 				Action:    audit.ActionGitSyncValidationFailed,
 				Resource:  audit.Resource{Type: "git_repo", ID: r.ID},
 				TeamID:    teamID,
-				Metadata:  map[string]string{"name": r.Name, "file": f.RelPath, "error": parseErr.Error()},
+				Metadata:  map[string]string{"name": r.Name, "file": f.RelPath, "error": sanitizeURL(parseErr.Error())},
 			})
 			continue
 		}
@@ -108,7 +108,7 @@ func SyncRepo(ctx context.Context, database *sql.DB, store *repo.Store, r *repo.
 				Action:    audit.ActionGitSyncApplyFailed,
 				Resource:  audit.Resource{Type: "git_repo", ID: r.ID},
 				TeamID:    teamID,
-				Metadata:  map[string]string{"name": r.Name, "file": f.RelPath, "error": saveErr.Error()},
+				Metadata:  map[string]string{"name": r.Name, "file": f.RelPath, "error": sanitizeURL(saveErr.Error())},
 			})
 			continue
 		}

--- a/packages/engine/internal/repo/sync/engine_test.go
+++ b/packages/engine/internal/repo/sync/engine_test.go
@@ -179,6 +179,51 @@ func TestSyncRepo_PrunesRemovedFiles(t *testing.T) {
 	}
 }
 
+func TestPlanRepo_ClassifiesFiles(t *testing.T) {
+	database, store := setupEngineTest(t)
+	ctx := context.Background()
+	r, _ := store.Create(ctx, repo.CreateParams{
+		Name: "plan", URL: "https://example.com/a.git", Branch: "main",
+		Path: "/", PollInterval: "60s", Credential: "pat",
+	})
+	base := t.TempDir()
+	repoDir := filepath.Join(base, r.ID)
+	_ = os.MkdirAll(repoDir, 0o755)
+
+	// Set up two workflows: both get applied in the priming sync.
+	existingYAML := validWorkflowYAML("existing")
+	_ = os.WriteFile(filepath.Join(repoDir, "existing.yaml"), []byte(existingYAML), 0o644)
+	_ = os.WriteFile(filepath.Join(repoDir, "new.yaml"), []byte(validWorkflowYAML("new")), 0o644)
+
+	// Prime the DB: apply both files so their hashes are recorded.
+	driver := &NoopDriver{BasePath: base, SHA: "sha-before"}
+	if _, err := SyncRepo(ctx, database, store, r, driver); err != nil {
+		t.Fatalf("priming sync: %v", err)
+	}
+
+	// Now modify existing.yaml so its hash differs from what is in the DB.
+	_ = os.WriteFile(filepath.Join(repoDir, "existing.yaml"),
+		[]byte(existingYAML+"# changed\n"), 0o644)
+
+	// Plan should see: existing changed → would apply (1), new unchanged (1).
+	report, err := PlanRepo(ctx, database, r, driver)
+	if err != nil {
+		t.Fatalf("PlanRepo: %v", err)
+	}
+	if report.Applied != 1 || report.Unchanged != 1 {
+		t.Errorf("PlanRepo: applied=%d unchanged=%d, want 1/1", report.Applied, report.Unchanged)
+	}
+
+	// Crucially: plan must NOT have written a new version of "existing".
+	var count int
+	_ = database.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM workflow_definitions WHERE name = 'existing'`,
+	).Scan(&count)
+	if count != 1 {
+		t.Errorf("plan should not write: got %d versions of 'existing', want 1", count)
+	}
+}
+
 func TestSyncRepo_InvalidFileDoesNotAbortOthers(t *testing.T) {
 	database, store := setupEngineTest(t)
 	ctx := context.Background()

--- a/packages/engine/internal/repo/sync/engine_test.go
+++ b/packages/engine/internal/repo/sync/engine_test.go
@@ -129,6 +129,56 @@ func TestSyncRepo_UnchangedYieldsNoApply(t *testing.T) {
 	}
 }
 
+func TestSyncRepo_PrunesRemovedFiles(t *testing.T) {
+	database, store := setupEngineTest(t)
+	ctx := context.Background()
+	r, _ := store.Create(ctx, repo.CreateParams{
+		Name: "pru", URL: "https://example.com/a.git", Branch: "main",
+		Path: "/", PollInterval: "60s", Credential: "pat",
+		AutoApply: true, Prune: true,
+	})
+	base := t.TempDir()
+	repoDir := filepath.Join(base, r.ID)
+	_ = os.MkdirAll(repoDir, 0o755)
+
+	// First sync: two workflows present.
+	_ = os.WriteFile(filepath.Join(repoDir, "a.yaml"), []byte(validWorkflowYAML("a")), 0o644)
+	_ = os.WriteFile(filepath.Join(repoDir, "b.yaml"), []byte(validWorkflowYAML("b")), 0o644)
+	driver := &NoopDriver{BasePath: base, SHA: "first"}
+	if _, err := SyncRepo(ctx, database, store, r, driver); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	// Second sync: b.yaml is gone.
+	_ = os.Remove(filepath.Join(repoDir, "b.yaml"))
+	driver.SHA = "second"
+	report, err := SyncRepo(ctx, database, store, r, driver)
+	if err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if report.Pruned != 1 {
+		t.Errorf("Pruned: got %d, want 1", report.Pruned)
+	}
+
+	// b should now be disabled (latest version has disabled_at IS NOT NULL).
+	var disabledB sql.NullTime
+	_ = database.QueryRowContext(ctx,
+		`SELECT disabled_at FROM workflow_definitions WHERE name = 'b' ORDER BY version DESC LIMIT 1`,
+	).Scan(&disabledB)
+	if !disabledB.Valid {
+		t.Error("workflow b should be disabled after prune")
+	}
+
+	// a should still be enabled.
+	var disabledA sql.NullTime
+	_ = database.QueryRowContext(ctx,
+		`SELECT disabled_at FROM workflow_definitions WHERE name = 'a' ORDER BY version DESC LIMIT 1`,
+	).Scan(&disabledA)
+	if disabledA.Valid {
+		t.Error("workflow a should stay enabled")
+	}
+}
+
 func TestSyncRepo_InvalidFileDoesNotAbortOthers(t *testing.T) {
 	database, store := setupEngineTest(t)
 	ctx := context.Background()

--- a/packages/engine/internal/repo/sync/prune.go
+++ b/packages/engine/internal/repo/sync/prune.go
@@ -1,0 +1,70 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// RecordSeen upserts a git_repo_workflows row marking that repoID has
+// a file producing workflowName in the current sync pass. Idempotent —
+// safe to call multiple times for the same (repo, workflow) pair.
+func RecordSeen(ctx context.Context, database *sql.DB, repoID, workflowName string) error {
+	_, err := database.ExecContext(ctx,
+		`INSERT INTO git_repo_workflows (repo_id, workflow_name, last_seen_at)
+		 VALUES ($1, $2, NOW())
+		 ON CONFLICT (repo_id, workflow_name) DO UPDATE SET last_seen_at = NOW()`,
+		repoID, workflowName,
+	)
+	if err != nil {
+		return fmt.Errorf("recording seen workflow %q for repo %s: %w", workflowName, repoID, err)
+	}
+	return nil
+}
+
+// ListStale returns the names of workflows owned by repoID whose
+// last_seen_at predates syncStart — i.e., files that used to be in
+// the repo but aren't anymore. Callers use this to drive prune.
+func ListStale(ctx context.Context, database *sql.DB, repoID string, syncStart time.Time) ([]string, error) {
+	rows, err := database.QueryContext(ctx,
+		`SELECT workflow_name FROM git_repo_workflows
+		 WHERE repo_id = $1 AND last_seen_at < $2
+		 ORDER BY workflow_name`,
+		repoID, syncStart,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing stale workflows for repo %s: %w", repoID, err)
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, fmt.Errorf("scanning stale workflow: %w", err)
+		}
+		names = append(names, n)
+	}
+	return names, rows.Err()
+}
+
+// RemoveSeenRecords deletes git_repo_workflows rows for the given names.
+// Called after prune so a reappearing file is treated as a fresh
+// attribution rather than inheriting the stale last_seen_at.
+func RemoveSeenRecords(ctx context.Context, database *sql.DB, repoID string, names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+	_, err := database.ExecContext(ctx,
+		`DELETE FROM git_repo_workflows
+		 WHERE repo_id = $1 AND workflow_name = ANY(
+		     SELECT unnest($2::text[])
+		 )`,
+		repoID, names,
+	)
+	if err != nil {
+		return fmt.Errorf("removing stale workflow records for repo %s: %w", repoID, err)
+	}
+	return nil
+}

--- a/packages/engine/internal/repo/sync/prune_test.go
+++ b/packages/engine/internal/repo/sync/prune_test.go
@@ -1,0 +1,84 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+)
+
+func TestRecordSeen_UpsertsRow(t *testing.T) {
+	database, _ := setupEngineTest(t)
+	ctx := context.Background()
+	repoID := insertTestRepo(t, database, "r1")
+
+	if err := RecordSeen(ctx, database, repoID, "wf-a"); err != nil {
+		t.Fatalf("RecordSeen: %v", err)
+	}
+	if err := RecordSeen(ctx, database, repoID, "wf-a"); err != nil {
+		t.Fatalf("RecordSeen retry: %v", err)
+	}
+	var count int
+	_ = database.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM git_repo_workflows WHERE repo_id = $1 AND workflow_name = 'wf-a'`,
+		repoID,
+	).Scan(&count)
+	if count != 1 {
+		t.Errorf("expected exactly 1 row, got %d", count)
+	}
+}
+
+func TestListStale_ReturnsUnseenNames(t *testing.T) {
+	database, _ := setupEngineTest(t)
+	ctx := context.Background()
+	repoID := insertTestRepo(t, database, "r2")
+
+	_ = RecordSeen(ctx, database, repoID, "wf-a")
+	_ = RecordSeen(ctx, database, repoID, "wf-b")
+	time.Sleep(50 * time.Millisecond)
+	syncStart := time.Now()
+	time.Sleep(50 * time.Millisecond)
+	_ = RecordSeen(ctx, database, repoID, "wf-a") // touched in this sync window
+
+	stale, err := ListStale(ctx, database, repoID, syncStart)
+	if err != nil {
+		t.Fatalf("ListStale: %v", err)
+	}
+	if len(stale) != 1 || stale[0] != "wf-b" {
+		t.Errorf("stale: got %+v, want [wf-b]", stale)
+	}
+}
+
+func TestRemoveSeenRecords_DeletesByName(t *testing.T) {
+	database, _ := setupEngineTest(t)
+	ctx := context.Background()
+	repoID := insertTestRepo(t, database, "r3")
+	_ = RecordSeen(ctx, database, repoID, "wf-a")
+
+	if err := RemoveSeenRecords(ctx, database, repoID, []string{"wf-a"}); err != nil {
+		t.Fatalf("RemoveSeenRecords: %v", err)
+	}
+	var count int
+	_ = database.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM git_repo_workflows WHERE repo_id = $1`,
+		repoID,
+	).Scan(&count)
+	if count != 0 {
+		t.Errorf("expected 0 rows after removal, got %d", count)
+	}
+}
+
+func insertTestRepo(t *testing.T, database *sql.DB, name string) string {
+	t.Helper()
+	var id string
+	err := database.QueryRow(
+		`INSERT INTO git_repos (name, url, credential)
+		 VALUES ($1, 'https://example.com/r.git', 'pat')
+		 RETURNING id`,
+		name,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert test repo: %v", err)
+	}
+	return id
+}

--- a/packages/engine/internal/repo/sync/sanitize.go
+++ b/packages/engine/internal/repo/sync/sanitize.go
@@ -1,0 +1,15 @@
+package sync
+
+import "regexp"
+
+// urlCredPattern matches https://user:password@host — the only URL
+// form that can embed plaintext credentials that we need to strip
+// before putting go-git errors into audit metadata. SSH URLs
+// (git@host:path) are left untouched.
+var urlCredPattern = regexp.MustCompile(`(https?://[^:\s/]+):([^@\s]+)@`)
+
+// sanitizeURL redacts inline credentials from any HTTP(S) URLs in msg.
+// Returns the original string when no credentialed URL is present.
+func sanitizeURL(msg string) string {
+	return urlCredPattern.ReplaceAllString(msg, "$1:***@")
+}

--- a/packages/engine/internal/repo/sync/sanitize_test.go
+++ b/packages/engine/internal/repo/sync/sanitize_test.go
@@ -1,0 +1,22 @@
+package sync
+
+import "testing"
+
+func TestSanitizeURL(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"plain message no url", "plain message no url"},
+		{"clone: https://github.com/acme/wf.git not found", "clone: https://github.com/acme/wf.git not found"},
+		{"clone: https://user:sekrit@github.com/acme/wf.git 401", "clone: https://user:***@github.com/acme/wf.git 401"},
+		{"ssh: git@github.com:acme/wf.git ok", "ssh: git@github.com:acme/wf.git ok"},
+		{"fetch https://u:p@a.com/r.git and https://x:y@b.com/r.git both failed",
+			"fetch https://u:***@a.com/r.git and https://x:***@b.com/r.git both failed"},
+	}
+	for _, c := range cases {
+		got := sanitizeURL(c.in)
+		if got != c.want {
+			t.Errorf("sanitizeURL(%q)\n  got  %q\n  want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/packages/engine/internal/repo/types.go
+++ b/packages/engine/internal/repo/types.go
@@ -34,6 +34,11 @@ type Repo struct {
 	AutoApply     bool
 	Prune         bool
 	Enabled       bool
+	// WebhookSecret is the HMAC shared secret used to verify inbound push
+	// webhooks from the git provider. SECURITY: this value is sensitive and
+	// MUST NOT be printed to terminal or logs. The CLI intentionally never
+	// renders it; any new caller must follow the same discipline.
+	WebhookSecret string
 	LastSyncSHA   string
 	LastSyncAt    *time.Time
 	LastSyncError string

--- a/packages/engine/internal/server/git_webhook.go
+++ b/packages/engine/internal/server/git_webhook.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dvflw/mantle/internal/audit"
+	"github.com/dvflw/mantle/internal/repo"
+	reposync "github.com/dvflw/mantle/internal/repo/sync"
+)
+
+// GitWebhookHandler serves POST /hooks/git/<repo-id>. It verifies the
+// HMAC-SHA256 signature using the repo's webhook_secret, emits a
+// git.push.received audit event, and fires SyncRepo in a goroutine so
+// the webhook responds within the git provider's timeout.
+type GitWebhookHandler struct {
+	DB     *sql.DB
+	Store  *repo.Store
+	Driver reposync.Driver
+}
+
+func (h *GitWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := strings.TrimPrefix(r.URL.Path, "/hooks/git/")
+	if id == "" || strings.Contains(id, "/") {
+		http.Error(w, `{"error":"bad repo id"}`, http.StatusBadRequest)
+		return
+	}
+
+	repoRow, err := h.Store.GetByID(r.Context(), id)
+	if err != nil {
+		http.Error(w, `{"error":"repo not found"}`, http.StatusNotFound)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, `{"error":"bad body"}`, http.StatusBadRequest)
+		return
+	}
+
+	if repoRow.WebhookSecret != "" {
+		if !verifyGitWebhookSignature(body, repoRow.WebhookSecret, r.Header) {
+			http.Error(w, `{"error":"invalid signature"}`, http.StatusForbidden)
+			return
+		}
+	}
+
+	emitGitAudit(context.Background(), h.DB, audit.Event{
+		Timestamp: time.Now(),
+		Actor:     "webhook",
+		Action:    audit.ActionGitPushReceived,
+		Resource:  audit.Resource{Type: "git_repo", ID: repoRow.ID},
+		Metadata:  map[string]string{"name": repoRow.Name},
+	})
+
+	// Fire sync in the background so the provider gets its 202 fast.
+	go func() {
+		_, _ = reposync.SyncRepo(context.Background(), h.DB, h.Store, repoRow, h.Driver)
+	}()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	fmt.Fprintf(w, `{"repo":"%s","accepted":true}`, repoRow.Name)
+}
+
+// verifyGitWebhookSignature accepts X-Hub-Signature-256 (GitHub) or
+// X-Signature-256 (generic). Returns false if absent or mismatched.
+// Kept separate from the workflow webhook's verifier so either can
+// change signature format without breaking the other.
+func verifyGitWebhookSignature(body []byte, secret string, headers http.Header) bool {
+	sigHeader := headers.Get("X-Hub-Signature-256")
+	if sigHeader == "" {
+		sigHeader = headers.Get("X-Signature-256")
+	}
+	if sigHeader == "" || !strings.HasPrefix(sigHeader, "sha256=") {
+		return false
+	}
+	sig, err := hex.DecodeString(sigHeader[len("sha256="):])
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hmac.Equal(sig, mac.Sum(nil))
+}
+
+// emitGitAudit opens a short-lived transaction for the audit write and
+// swallows errors — an audit emission failure must never fail a
+// webhook response. Named distinctly from the sync package's emit() so
+// linters don't flag the duplication.
+func emitGitAudit(ctx context.Context, database *sql.DB, e audit.Event) {
+	tx, err := database.BeginTx(ctx, nil)
+	if err != nil {
+		return
+	}
+	defer tx.Rollback() //nolint:errcheck
+	if err := audit.EmitTx(ctx, tx, e); err != nil {
+		return
+	}
+	_ = tx.Commit()
+}

--- a/packages/engine/internal/server/git_webhook.go
+++ b/packages/engine/internal/server/git_webhook.go
@@ -58,7 +58,7 @@ func (h *GitWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	emitGitAudit(context.Background(), h.DB, audit.Event{
+	emitGitAudit(r.Context(), h.DB, audit.Event{
 		Timestamp: time.Now(),
 		Actor:     "webhook",
 		Action:    audit.ActionGitPushReceived,
@@ -67,8 +67,11 @@ func (h *GitWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// Fire sync in the background so the provider gets its 202 fast.
+	// context.WithoutCancel propagates request values without tying the
+	// goroutine's lifetime to the HTTP request context.
+	syncCtx := context.WithoutCancel(r.Context())
 	go func() {
-		_, _ = reposync.SyncRepo(context.Background(), h.DB, h.Store, repoRow, h.Driver)
+		_, _ = reposync.SyncRepo(syncCtx, h.DB, h.Store, repoRow, h.Driver)
 	}()
 
 	w.Header().Set("Content-Type", "application/json")

--- a/packages/engine/internal/server/git_webhook_test.go
+++ b/packages/engine/internal/server/git_webhook_test.go
@@ -1,0 +1,136 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dvflw/mantle/internal/config"
+	"github.com/dvflw/mantle/internal/db"
+	"github.com/dvflw/mantle/internal/dbdefaults"
+	"github.com/dvflw/mantle/internal/repo"
+	reposync "github.com/dvflw/mantle/internal/repo/sync"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func setupWebhookTest(t *testing.T) (*sql.DB, *repo.Store) {
+	t.Helper()
+	ctx := context.Background()
+	pg, err := postgres.Run(ctx,
+		dbdefaults.PostgresImage,
+		postgres.WithDatabase(dbdefaults.TestDatabase),
+		postgres.WithUsername(dbdefaults.User),
+		postgres.WithPassword(dbdefaults.Password),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+	)
+	if err != nil {
+		if os.Getenv("CI") != "" {
+			t.Fatalf("Postgres (CI): %v", err)
+		}
+		t.Skipf("Postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.Terminate(ctx) })
+	connStr, _ := pg.ConnectionString(ctx, "sslmode=disable")
+	database, err := db.Open(config.DatabaseConfig{URL: connStr})
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	if err := db.Migrate(ctx, database); err != nil {
+		t.Fatalf("db.Migrate: %v", err)
+	}
+	return database, &repo.Store{DB: database, Actor: "test"}
+}
+
+func sign(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestGitWebhook_ValidSignature_202(t *testing.T) {
+	database, store := setupWebhookTest(t)
+	ctx := context.Background()
+
+	// Create a repo with a webhook_secret directly (Plan A doesn't expose
+	// a setter; write the column via SQL).
+	r, err := store.Create(ctx, repo.CreateParams{
+		Name: "acme", URL: "https://example.com/a.git", Branch: "main",
+		Path: "/", PollInterval: "60s", Credential: "pat",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	secret := "topsecret"
+	_, err = database.ExecContext(ctx,
+		`UPDATE git_repos SET webhook_secret = $1 WHERE id = $2`, secret, r.ID)
+	if err != nil {
+		t.Fatalf("set webhook_secret: %v", err)
+	}
+
+	h := &GitWebhookHandler{
+		DB:     database,
+		Store:  store,
+		Driver: &reposync.NoopDriver{BasePath: t.TempDir(), SHA: "sha-a"},
+	}
+	body := []byte(`{"hello":"world"}`)
+	req := httptest.NewRequest(http.MethodPost, "/hooks/git/"+r.ID, bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", sign(body, secret))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: got %d, want 202; body: %s", rec.Code, rec.Body.String())
+	}
+	if want := `"accepted":true`; !bytes.Contains(rec.Body.Bytes(), []byte(want)) {
+		t.Errorf("body missing %q: %s", want, rec.Body.String())
+	}
+}
+
+func TestGitWebhook_BadSignature_403(t *testing.T) {
+	database, store := setupWebhookTest(t)
+	ctx := context.Background()
+	r, _ := store.Create(ctx, repo.CreateParams{
+		Name: "acme2", URL: "https://example.com/a.git", Branch: "main",
+		Path: "/", PollInterval: "60s", Credential: "pat",
+	})
+	_, _ = database.ExecContext(ctx,
+		`UPDATE git_repos SET webhook_secret = 'real' WHERE id = $1`, r.ID)
+
+	h := &GitWebhookHandler{DB: database, Store: store, Driver: &reposync.NoopDriver{BasePath: t.TempDir()}}
+	req := httptest.NewRequest(http.MethodPost, "/hooks/git/"+r.ID, bytes.NewReader([]byte("x")))
+	req.Header.Set("X-Hub-Signature-256", "sha256=deadbeef")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status: got %d, want 403; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGitWebhook_UnknownRepo_404(t *testing.T) {
+	database, store := setupWebhookTest(t)
+	h := &GitWebhookHandler{DB: database, Store: store, Driver: &reposync.NoopDriver{BasePath: t.TempDir()}}
+	req := httptest.NewRequest(http.MethodPost, "/hooks/git/00000000-0000-0000-0000-000000000000", bytes.NewReader([]byte("{}")))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", rec.Code)
+	}
+	fmt.Println("ok")
+}

--- a/packages/engine/internal/server/git_webhook_test.go
+++ b/packages/engine/internal/server/git_webhook_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -132,5 +131,4 @@ func TestGitWebhook_UnknownRepo_404(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status: got %d, want 404", rec.Code)
 	}
-	fmt.Println("ok")
 }

--- a/packages/engine/internal/server/server.go
+++ b/packages/engine/internal/server/server.go
@@ -19,6 +19,8 @@ import (
 	"github.com/dvflw/mantle/internal/config"
 	"github.com/dvflw/mantle/internal/engine"
 	"github.com/dvflw/mantle/internal/metrics"
+	"github.com/dvflw/mantle/internal/repo"
+	reposync "github.com/dvflw/mantle/internal/repo/sync"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -35,6 +37,11 @@ type Server struct {
 	TLSCertFile   string
 	TLSKeyFile    string
 	Logger        *slog.Logger
+
+	// GitOps webhook support — set by the caller (e.g. serve.go) after New().
+	// Both fields may be nil in test contexts that don't exercise /hooks/git/.
+	RepoStore *repo.Store
+	GitDriver reposync.Driver
 
 	httpServer   *http.Server
 	cron         *CronScheduler
@@ -126,6 +133,15 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Prometheus metrics endpoint.
 	mux.Handle("/metrics", promhttp.Handler())
+
+	// Git push webhook endpoint — registered before the generic /hooks/ prefix
+	// so the more-specific path is explicit (Go's ServeMux uses longest-prefix
+	// match regardless of registration order, but explicit ordering is clearer).
+	mux.Handle("/hooks/git/", &GitWebhookHandler{
+		DB:     s.DB,
+		Store:  s.RepoStore,
+		Driver: s.GitDriver,
+	})
 
 	// Webhook endpoints.
 	mux.HandleFunc("/hooks/", s.webhooks.ServeHTTP)

--- a/packages/engine/internal/workflow/store.go
+++ b/packages/engine/internal/workflow/store.go
@@ -188,6 +188,48 @@ func GetVersion(ctx context.Context, database *sql.DB, name string, version int)
 	return content, nil
 }
 
+// Disable marks the latest version of the named workflow as disabled.
+// Older versions are untouched — history is preserved. Returns nil
+// with no error if the workflow does not exist (callers may disable
+// speculatively during a GitOps prune pass).
+func Disable(ctx context.Context, database *sql.DB, name string) error {
+	teamID := auth.TeamIDFromContext(ctx)
+	_, err := database.ExecContext(ctx,
+		`UPDATE workflow_definitions
+		 SET disabled_at = NOW()
+		 WHERE id = (
+		   SELECT id FROM workflow_definitions
+		   WHERE name = $1 AND team_id = $2
+		   ORDER BY version DESC LIMIT 1
+		 )`,
+		name, teamID,
+	)
+	if err != nil {
+		return fmt.Errorf("disabling workflow %q: %w", name, err)
+	}
+	return nil
+}
+
+// Reenable clears disabled_at on the latest version of the named
+// workflow. Safe to call when already enabled — becomes a no-op.
+func Reenable(ctx context.Context, database *sql.DB, name string) error {
+	teamID := auth.TeamIDFromContext(ctx)
+	_, err := database.ExecContext(ctx,
+		`UPDATE workflow_definitions
+		 SET disabled_at = NULL
+		 WHERE id = (
+		   SELECT id FROM workflow_definitions
+		   WHERE name = $1 AND team_id = $2
+		   ORDER BY version DESC LIMIT 1
+		 )`,
+		name, teamID,
+	)
+	if err != nil {
+		return fmt.Errorf("reenabling workflow %q: %w", name, err)
+	}
+	return nil
+}
+
 func sha256Hash(data []byte) string {
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])

--- a/packages/engine/internal/workflow/store_test.go
+++ b/packages/engine/internal/workflow/store_test.go
@@ -195,3 +195,49 @@ func TestGetLatestVersion_NoVersions(t *testing.T) {
 		t.Errorf("GetLatestVersion() = %d, want 0", version)
 	}
 }
+
+func TestDisable_MarksLatestVersion(t *testing.T) {
+	database := setupTestDB(t)
+	ctx := context.Background()
+	raw := []byte("name: wf\nsteps:\n  - name: s\n    action: http/request\n")
+	result, err := ParseBytes(raw)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if _, err := Save(ctx, database, result, raw); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := Disable(ctx, database, "wf"); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	var disabled sql.NullTime
+	if err := database.QueryRowContext(ctx,
+		`SELECT disabled_at FROM workflow_definitions WHERE name = 'wf' ORDER BY version DESC LIMIT 1`,
+	).Scan(&disabled); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if !disabled.Valid {
+		t.Error("disabled_at should be non-null after Disable")
+	}
+}
+
+func TestReenable_ClearsDisabledAt(t *testing.T) {
+	database := setupTestDB(t)
+	ctx := context.Background()
+	raw := []byte("name: wf2\nsteps:\n  - name: s\n    action: http/request\n")
+	result, _ := ParseBytes(raw)
+	if _, err := Save(ctx, database, result, raw); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_ = Disable(ctx, database, "wf2")
+	if err := Reenable(ctx, database, "wf2"); err != nil {
+		t.Fatalf("Reenable: %v", err)
+	}
+	var disabled sql.NullTime
+	_ = database.QueryRowContext(ctx,
+		`SELECT disabled_at FROM workflow_definitions WHERE name = 'wf2' ORDER BY version DESC LIMIT 1`,
+	).Scan(&disabled)
+	if disabled.Valid {
+		t.Error("disabled_at should be null after Reenable")
+	}
+}


### PR DESCRIPTION
## Summary

Plan C (final) for issue #16 — completes the core GitOps loop. Plans A (#133) and B (#134) are already merged.

- **Prune** — migration 020 adds `workflow_definitions.disabled_at` and a `git_repo_workflows` join table. The sync engine records each seen workflow per repo, then disables any that disappeared when `prune: true`. Reappearing files clear `disabled_at` on the next sync. History preserved.
- **Webhook receiver** — `POST /hooks/git/<repo-id>` verifies HMAC-SHA256 via `X-Hub-Signature-256`, emits `git.push.received`, and fires `SyncRepo` in a goroutine so the provider gets its 202 fast. Body size capped at 1 MiB. Constant-time HMAC comparison.
- **Manual flow** — `mantle repos plan <name>` previews pending changes without writing; `mantle repos apply <name>` syncs on demand for `auto_apply: false` repos.
- **Delete cleanup** — `repo.Store.Delete` now removes the cloned working tree under `<artifact>/git/<repo-id>/` when a repo is unregistered. DB `ON DELETE CASCADE` handles the join-table rows automatically.
- **URL sanitization** — `sanitizeURL` strips `user:password@` from URLs in audit metadata and `last_sync_error`, so go-git errors echoing a clone URL can't leak inline credentials.
- **`mantle repos update`** — wires the existing `Store.Update` into a CLI subcommand for in-place edits.
- **`--webhook-secret` flag** on `repos add` and `repos update` so operators can arm HMAC verification without raw SQL.
- **Audit events** — `git.sync.pruned`, `git.push.received`.

## What operators can do with A + B + C

- Register repos (CLI or `git_sync.repos:` in `mantle.yaml`)
- Run `mantle serve` — reconciler materializes config, poller syncs each enabled `auto_apply: true` repo at `poll_interval`
- Set up push webhooks (`POST /hooks/git/<id>` + `X-Hub-Signature-256`) for immediate syncs
- Preview (`plan`), manually apply (`apply`), or force-sync (`sync`) on any repo
- Delete a repo — DB row + cloned working tree + join-table rows all clean up
- Pruned workflows survive as disabled versions in history, ready to be re-enabled if the file reappears

Closes the core GitOps loop of #16.

## Test plan

- [ ] `go test ./...` passes in CI
- [ ] `go test ./internal/repo/sync/` — prune, URL sanitization, PlanRepo
- [ ] `go test ./internal/repo/` — GetByID, Delete cleanup, webhook_secret persistence
- [ ] `go test ./internal/server/` — webhook handler (202 / 403 / 404)
- [ ] `go test ./internal/cli/` — repos plan, apply, update, webhook-secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)