### PR TITLE
fix(release): publish v-prefixed GHCR image tags and align Helm appVersion

### DIFF
--- a/packages/engine/.goreleaser.yaml
+++ b/packages/engine/.goreleaser.yaml
@@ -68,6 +68,12 @@ dockers_v2:
       - "--platform=linux/arm64"
 
 docker_manifests:
+  # v-prefixed tag (e.g. v0.4.0) — the canonical form users and Helm charts reference.
+  - name_template: "ghcr.io/dvflw/mantle:v{{ .Version }}"
+    image_templates:
+      - "ghcr.io/dvflw/mantle:{{ .Version }}-amd64"
+      - "ghcr.io/dvflw/mantle:{{ .Version }}-arm64"
+  # Bare version without v prefix (e.g. 0.4.0) for tooling that strips it.
   - name_template: "ghcr.io/dvflw/mantle:{{ .Version }}"
     image_templates:
       - "ghcr.io/dvflw/mantle:{{ .Version }}-amd64"

--- a/packages/helm-chart/Chart.yaml
+++ b/packages/helm-chart/Chart.yaml
@@ -3,4 +3,4 @@ name: mantle
 description: Headless AI workflow automation platform
 type: application
 version: 0.1.0
-appVersion: "0.1.0"
+appVersion: "0.4.0"

--- a/packages/helm-chart/templates/deployment.yaml
+++ b/packages/helm-chart/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 40
       containers:
         - name: mantle
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/packages/helm-chart/templates/migration-job.yaml
+++ b/packages/helm-chart/templates/migration-job.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
         - name: migrate
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with $.Values.securityContext }}
           securityContext:

--- a/packages/helm-chart/values.yaml
+++ b/packages/helm-chart/values.yaml
@@ -2,7 +2,9 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/dvflw/mantle
-  tag: latest
+  # tag defaults to the chart's appVersion (e.g. v0.4.0) when left empty.
+  # Override to pin a specific release: --set image.tag=v0.5.0
+  tag: ""
   pullPolicy: IfNotPresent
 
 database:


### PR DESCRIPTION
Closes #136

## Problem

goreleaser was publishing `ghcr.io/dvflw/mantle:0.4.0` (bare semver) but not the `v`-prefixed form (`v0.4.0`) that Kubernetes manifests, Helm `--set image.tag=`, and most container tooling conventionally use. The `latest` tag pushed fine because it has no version in it, but pinned version references silently failed to resolve.

## Changes

### `.goreleaser.yaml`
- Added a `v{{ .Version }}` docker manifest entry (e.g. `ghcr.io/dvflw/mantle:v0.4.0`) alongside the existing bare `{{ .Version }}` manifest. Both are pushed on every non-snapshot, non-prerelease.
- Existing `major.minor`, `major`, and `latest` manifests are unchanged.

### Helm chart
- `values.yaml`: changed `image.tag` default from `"latest"` to `""` — documents that it falls back to the chart's `appVersion`.
- `templates/deployment.yaml`: image tag falls back to `v<appVersion>` when `image.tag` is empty, keeping the chart self-consistent with the release.
- `Chart.yaml`: bumped `appVersion` from `0.1.0` → `0.4.0` to match the current engine release.

## Test plan

- [ ] On next engine release, verify both `ghcr.io/dvflw/mantle:v<X.Y.Z>` and `ghcr.io/dvflw/mantle:<X.Y.Z>` resolve.
- [ ] `helm template` with default values produces `image: ghcr.io/dvflw/mantle:v0.4.0`.
- [ ] `helm template` with `--set image.tag=v0.5.0` overrides correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)