### PR TITLE
feat(connector): add notion/create_page and notion/query_database

### DIFF
--- a/packages/engine/internal/connector/connector.go
+++ b/packages/engine/internal/connector/connector.go
@@ -44,6 +44,8 @@ func NewRegistry() *Registry {
 	r.Register("github/dispatch", &GitHubDispatchConnector{})
 	r.Register("linear/create_issue", &LinearCreateIssueConnector{})
 	r.Register("linear/search", &LinearSearchConnector{})
+	r.Register("notion/create_page", &NotionCreatePageConnector{})
+	r.Register("notion/query_database", &NotionQueryDatabaseConnector{})
 	return r
 }
 

--- a/packages/engine/internal/connector/notion.go
+++ b/packages/engine/internal/connector/notion.go
@@ -1,0 +1,221 @@
+package connector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	notionBaseURL = "https://api.notion.com/v1"
+	notionVersion = "2022-06-28"
+)
+
+// NotionCreatePageConnector creates a page in a Notion database or under a parent page.
+type NotionCreatePageConnector struct {
+	Client  *http.Client
+	baseURL string // override for testing
+}
+
+func (c *NotionCreatePageConnector) apiURL(path string) string {
+	base := c.baseURL
+	if base == "" {
+		base = notionBaseURL
+	}
+	return base + path
+}
+
+func (c *NotionCreatePageConnector) Execute(ctx context.Context, params map[string]any) (map[string]any, error) {
+	token, err := extractNotionToken(params)
+	if err != nil {
+		return nil, fmt.Errorf("notion/create_page: %w", err)
+	}
+
+	parentDBID, _ := params["parent_database_id"].(string)
+	parentPageID, _ := params["parent_page_id"].(string)
+	if parentDBID == "" && parentPageID == "" {
+		return nil, fmt.Errorf("notion/create_page: parent_database_id or parent_page_id is required")
+	}
+
+	var parent map[string]any
+	if parentDBID != "" {
+		parent = map[string]any{"database_id": parentDBID}
+	} else {
+		parent = map[string]any{"page_id": parentPageID}
+	}
+
+	// Merge caller-supplied properties, then add title shorthand if not already set.
+	properties := map[string]any{}
+	if p, ok := params["properties"].(map[string]any); ok {
+		for k, v := range p {
+			properties[k] = v
+		}
+	}
+	if title, ok := params["title"].(string); ok && title != "" {
+		if _, exists := properties["title"]; !exists {
+			properties["title"] = map[string]any{
+				"title": []any{
+					map[string]any{"text": map[string]any{"content": title}},
+				},
+			}
+		}
+	}
+
+	body := map[string]any{
+		"parent":     parent,
+		"properties": properties,
+	}
+	if children, ok := params["children"].([]any); ok && len(children) > 0 {
+		body["children"] = children
+	}
+
+	reqJSON, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("notion/create_page: marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.apiURL("/pages"), bytes.NewReader(reqJSON))
+	if err != nil {
+		return nil, fmt.Errorf("notion/create_page: creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Notion-Version", notionVersion)
+
+	resp, err := httpClient(c.Client).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("notion/create_page: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, DefaultMaxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("notion/create_page: reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("notion/create_page: Notion API returned %d: %s", resp.StatusCode, truncate(string(respBody), 500))
+	}
+
+	var page struct {
+		ID             string `json:"id"`
+		URL            string `json:"url"`
+		CreatedTime    string `json:"created_time"`
+		LastEditedTime string `json:"last_edited_time"`
+	}
+	if err := json.Unmarshal(respBody, &page); err != nil {
+		return nil, fmt.Errorf("notion/create_page: parsing response: %w", err)
+	}
+
+	return map[string]any{
+		"id":               page.ID,
+		"url":              page.URL,
+		"created_time":     page.CreatedTime,
+		"last_edited_time": page.LastEditedTime,
+	}, nil
+}
+
+// NotionQueryDatabaseConnector queries a Notion database.
+type NotionQueryDatabaseConnector struct {
+	Client  *http.Client
+	baseURL string // override for testing
+}
+
+func (c *NotionQueryDatabaseConnector) apiURL(path string) string {
+	base := c.baseURL
+	if base == "" {
+		base = notionBaseURL
+	}
+	return base + path
+}
+
+func (c *NotionQueryDatabaseConnector) Execute(ctx context.Context, params map[string]any) (map[string]any, error) {
+	token, err := extractNotionToken(params)
+	if err != nil {
+		return nil, fmt.Errorf("notion/query_database: %w", err)
+	}
+
+	databaseID, _ := params["database_id"].(string)
+	if databaseID == "" {
+		return nil, fmt.Errorf("notion/query_database: database_id is required")
+	}
+
+	body := map[string]any{}
+	if filter, ok := params["filter"].(map[string]any); ok {
+		body["filter"] = filter
+	}
+	if sorts, ok := params["sorts"].([]any); ok && len(sorts) > 0 {
+		body["sorts"] = sorts
+	}
+	if pageSize, ok := extractInt(params["page_size"]); ok && pageSize > 0 {
+		body["page_size"] = pageSize
+	}
+	if cursor, ok := params["start_cursor"].(string); ok && cursor != "" {
+		body["start_cursor"] = cursor
+	}
+
+	reqJSON, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("notion/query_database: marshaling request: %w", err)
+	}
+
+	path := fmt.Sprintf("/databases/%s/query", databaseID)
+	req, err := http.NewRequestWithContext(ctx, "POST", c.apiURL(path), bytes.NewReader(reqJSON))
+	if err != nil {
+		return nil, fmt.Errorf("notion/query_database: creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Notion-Version", notionVersion)
+
+	resp, err := httpClient(c.Client).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("notion/query_database: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, DefaultMaxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("notion/query_database: reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("notion/query_database: Notion API returned %d: %s", resp.StatusCode, truncate(string(respBody), 500))
+	}
+
+	var result struct {
+		Results    []any  `json:"results"`
+		NextCursor string `json:"next_cursor"`
+		HasMore    bool   `json:"has_more"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("notion/query_database: parsing response: %w", err)
+	}
+
+	out := map[string]any{
+		"results":  result.Results,
+		"has_more": result.HasMore,
+		"count":    len(result.Results),
+	}
+	if result.NextCursor != "" {
+		out["next_cursor"] = result.NextCursor
+	}
+	return out, nil
+}
+
+// extractNotionToken pulls the Notion integration token from _credential.
+func extractNotionToken(params map[string]any) (string, error) {
+	cred, ok := params["_credential"].(map[string]string)
+	if !ok {
+		return "", fmt.Errorf("credential is required")
+	}
+	delete(params, "_credential")
+	token := cred["token"]
+	if token == "" {
+		return "", fmt.Errorf("credential must contain a 'token' field")
+	}
+	return token, nil
+}

--- a/packages/engine/internal/connector/notion.go
+++ b/packages/engine/internal/connector/notion.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 const (
@@ -169,7 +170,7 @@ func (c *NotionQueryDatabaseConnector) Execute(ctx context.Context, params map[s
 		return nil, fmt.Errorf("notion/query_database: marshaling request: %w", err)
 	}
 
-	path := fmt.Sprintf("/databases/%s/query", databaseID)
+	path := fmt.Sprintf("/databases/%s/query", url.PathEscape(databaseID))
 	req, err := http.NewRequestWithContext(ctx, "POST", c.apiURL(path), bytes.NewReader(reqJSON))
 	if err != nil {
 		return nil, fmt.Errorf("notion/query_database: creating request: %w", err)
@@ -214,13 +215,24 @@ func (c *NotionQueryDatabaseConnector) Execute(ctx context.Context, params map[s
 }
 
 // extractNotionToken pulls the Notion integration token from _credential.
+// Accepts both map[string]string (engine-injected) and map[string]any
+// (JSON/CEL-deserialised) credential shapes.
 func extractNotionToken(params map[string]any) (string, error) {
-	cred, ok := params["_credential"].(map[string]string)
-	if !ok {
+	raw, ok := params["_credential"]
+	if !ok || raw == nil {
 		return "", fmt.Errorf("credential is required")
 	}
 	delete(params, "_credential")
-	token := cred["token"]
+
+	var token string
+	switch cred := raw.(type) {
+	case map[string]string:
+		token = cred["token"]
+	case map[string]any:
+		token, _ = cred["token"].(string)
+	default:
+		return "", fmt.Errorf("credential is required")
+	}
 	if token == "" {
 		return "", fmt.Errorf("credential must contain a 'token' field")
 	}

--- a/packages/engine/internal/connector/notion.go
+++ b/packages/engine/internal/connector/notion.go
@@ -48,6 +48,13 @@ func (c *NotionCreatePageConnector) Execute(ctx context.Context, params map[stri
 	}
 
 	// Merge caller-supplied properties, then add title shorthand if not already set.
+	// title_key names the database column that holds the title (defaults to "title";
+	// many databases use "Name" or another user-defined label).
+	titleKey := "title"
+	if k, ok := params["title_key"].(string); ok && k != "" {
+		titleKey = k
+	}
+
 	properties := map[string]any{}
 	if p, ok := params["properties"].(map[string]any); ok {
 		for k, v := range p {
@@ -55,8 +62,8 @@ func (c *NotionCreatePageConnector) Execute(ctx context.Context, params map[stri
 		}
 	}
 	if title, ok := params["title"].(string); ok && title != "" {
-		if _, exists := properties["title"]; !exists {
-			properties["title"] = map[string]any{
+		if _, exists := properties[titleKey]; !exists {
+			properties[titleKey] = map[string]any{
 				"title": []any{
 					map[string]any{"text": map[string]any{"content": title}},
 				},

--- a/packages/engine/internal/connector/notion_test.go
+++ b/packages/engine/internal/connector/notion_test.go
@@ -1,0 +1,400 @@
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func notionPageResponse() map[string]any {
+	return map[string]any{
+		"id":               "page-uuid-1",
+		"url":              "https://www.notion.so/Test-Page-page-uuid-1",
+		"created_time":     "2024-01-01T00:00:00.000Z",
+		"last_edited_time": "2024-01-01T00:00:00.000Z",
+	}
+}
+
+func TestNotionCreatePageConnector_CreatesPageInDatabase(t *testing.T) {
+	var gotAuth, gotVersion string
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotVersion = r.Header.Get("Notion-Version")
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(notionPageResponse())
+	}))
+	defer server.Close()
+
+	c := &NotionCreatePageConnector{baseURL: server.URL}
+	out, err := c.Execute(context.Background(), map[string]any{
+		"parent_database_id": "db-uuid-1",
+		"title":              "Test Page",
+		"_credential":        map[string]string{"token": "secret_test"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	if gotAuth != "Bearer secret_test" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer secret_test")
+	}
+	if gotVersion != notionVersion {
+		t.Errorf("Notion-Version = %q, want %q", gotVersion, notionVersion)
+	}
+	parent, _ := gotBody["parent"].(map[string]any)
+	if parent["database_id"] != "db-uuid-1" {
+		t.Errorf("parent.database_id = %q, want db-uuid-1", parent["database_id"])
+	}
+	if out["id"] != "page-uuid-1" {
+		t.Errorf("id = %q, want page-uuid-1", out["id"])
+	}
+	if out["url"] != "https://www.notion.so/Test-Page-page-uuid-1" {
+		t.Errorf("url = %q", out["url"])
+	}
+}
+
+func TestNotionCreatePageConnector_CreatesPageUnderPage(t *testing.T) {
+	var gotParent map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		gotParent, _ = body["parent"].(map[string]any)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(notionPageResponse())
+	}))
+	defer server.Close()
+
+	c := &NotionCreatePageConnector{baseURL: server.URL}
+	if _, err := c.Execute(context.Background(), map[string]any{
+		"parent_page_id": "parent-page-uuid",
+		"_credential":    map[string]string{"token": "secret_test"},
+	}); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	if gotParent["page_id"] != "parent-page-uuid" {
+		t.Errorf("parent.page_id = %q, want parent-page-uuid", gotParent["page_id"])
+	}
+	if _, hasDatabaseID := gotParent["database_id"]; hasDatabaseID {
+		t.Error("parent should not contain database_id for page parent")
+	}
+}
+
+func TestNotionCreatePageConnector_TitleSetInProperties(t *testing.T) {
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(notionPageResponse())
+	}))
+	defer server.Close()
+
+	c := &NotionCreatePageConnector{baseURL: server.URL}
+	if _, err := c.Execute(context.Background(), map[string]any{
+		"parent_database_id": "db-uuid-1",
+		"title":              "My Page",
+		"_credential":        map[string]string{"token": "secret_test"},
+	}); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	props, _ := gotBody["properties"].(map[string]any)
+	titleProp, ok := props["title"].(map[string]any)
+	if !ok {
+		t.Fatal("properties.title missing or wrong type")
+	}
+	titleArr, _ := titleProp["title"].([]any)
+	if len(titleArr) == 0 {
+		t.Fatal("properties.title.title is empty")
+	}
+	text, _ := titleArr[0].(map[string]any)
+	textContent, _ := text["text"].(map[string]any)
+	if textContent["content"] != "My Page" {
+		t.Errorf("title content = %q, want My Page", textContent["content"])
+	}
+}
+
+func TestNotionCreatePageConnector_ExplicitPropertiesNotOverriddenByTitle(t *testing.T) {
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(notionPageResponse())
+	}))
+	defer server.Close()
+
+	customTitle := map[string]any{
+		"title": []any{map[string]any{"text": map[string]any{"content": "Explicit Title"}}},
+	}
+	c := &NotionCreatePageConnector{baseURL: server.URL}
+	if _, err := c.Execute(context.Background(), map[string]any{
+		"parent_database_id": "db-uuid-1",
+		"title":              "Ignored Title",
+		"properties":         map[string]any{"title": customTitle},
+		"_credential":        map[string]string{"token": "secret_test"},
+	}); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	props, _ := gotBody["properties"].(map[string]any)
+	titleProp, _ := props["title"].(map[string]any)
+	titleArr, _ := titleProp["title"].([]any)
+	text, _ := titleArr[0].(map[string]any)
+	textContent, _ := text["text"].(map[string]any)
+	if textContent["content"] != "Explicit Title" {
+		t.Errorf("explicit properties.title was overridden by title shorthand: content = %q", textContent["content"])
+	}
+}
+
+func TestNotionCreatePageConnector_MissingParent(t *testing.T) {
+	c := &NotionCreatePageConnector{}
+	_, err := c.Execute(context.Background(), map[string]any{
+		"title":       "Test",
+		"_credential": map[string]string{"token": "secret_test"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing parent")
+	}
+}
+
+func TestNotionCreatePageConnector_MissingCredential(t *testing.T) {
+	c := &NotionCreatePageConnector{}
+	_, err := c.Execute(context.Background(), map[string]any{
+		"parent_database_id": "db-uuid-1",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing credential")
+	}
+}
+
+func TestNotionCreatePageConnector_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"object":"error","status":401,"message":"API token is invalid."}`))
+	}))
+	defer server.Close()
+
+	c := &NotionCreatePageConnector{baseURL: server.URL}
+	_, err := c.Execute(context.Background(), map[string]any{
+		"parent_database_id": "db-uuid-1",
+		"title":              "Test",
+		"_credential":        map[string]string{"token": "bad_token"},
+	})
+	if err == nil {
+		t.Fatal("expected error for API error response")
+	}
+}
+
+func TestNotionCreatePageConnector_CredentialDeleted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(notionPageResponse())
+	}))
+	defer server.Close()
+
+	params := map[string]any{
+		"parent_database_id": "db-uuid-1",
+		"title":              "Test",
+		"_credential":        map[string]string{"token": "secret_test"},
+	}
+	c := &NotionCreatePageConnector{baseURL: server.URL}
+	if _, err := c.Execute(context.Background(), params); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if _, exists := params["_credential"]; exists {
+		t.Error("_credential should be deleted from params after execution")
+	}
+}
+
+func TestNotionQueryDatabaseConnector_ReturnsResults(t *testing.T) {
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		if r.URL.Path != "/databases/db-uuid-1/query" {
+			t.Errorf("path = %q, want /databases/db-uuid-1/query", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"results": []any{
+				map[string]any{"id": "page-1", "object": "page"},
+				map[string]any{"id": "page-2", "object": "page"},
+			},
+			"next_cursor": nil,
+			"has_more":    false,
+		})
+	}))
+	defer server.Close()
+
+	c := &NotionQueryDatabaseConnector{baseURL: server.URL}
+	out, err := c.Execute(context.Background(), map[string]any{
+		"database_id": "db-uuid-1",
+		"page_size":   float64(10),
+		"_credential": map[string]string{"token": "secret_test"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	if gotBody["page_size"] != float64(10) {
+		t.Errorf("page_size = %v, want 10", gotBody["page_size"])
+	}
+	count, _ := out["count"].(int)
+	if count != 2 {
+		t.Errorf("count = %d, want 2", count)
+	}
+	results, _ := out["results"].([]any)
+	if len(results) != 2 {
+		t.Errorf("len(results) = %d, want 2", len(results))
+	}
+	if out["has_more"] != false {
+		t.Errorf("has_more = %v, want false", out["has_more"])
+	}
+}
+
+func TestNotionQueryDatabaseConnector_WithFilterAndSorts(t *testing.T) {
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"results": []any{}, "has_more": false,
+		})
+	}))
+	defer server.Close()
+
+	filter := map[string]any{
+		"property": "Status",
+		"select":   map[string]any{"equals": "Done"},
+	}
+	sorts := []any{
+		map[string]any{"property": "Created", "direction": "descending"},
+	}
+
+	c := &NotionQueryDatabaseConnector{baseURL: server.URL}
+	if _, err := c.Execute(context.Background(), map[string]any{
+		"database_id": "db-uuid-1",
+		"filter":      filter,
+		"sorts":       sorts,
+		"_credential": map[string]string{"token": "secret_test"},
+	}); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	if _, ok := gotBody["filter"]; !ok {
+		t.Error("expected filter in request body")
+	}
+	if _, ok := gotBody["sorts"]; !ok {
+		t.Error("expected sorts in request body")
+	}
+}
+
+func TestNotionQueryDatabaseConnector_HasMore(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"results":     []any{map[string]any{"id": "page-1"}},
+			"next_cursor": "cursor-abc",
+			"has_more":    true,
+		})
+	}))
+	defer server.Close()
+
+	c := &NotionQueryDatabaseConnector{baseURL: server.URL}
+	out, err := c.Execute(context.Background(), map[string]any{
+		"database_id": "db-uuid-1",
+		"_credential": map[string]string{"token": "secret_test"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	if out["has_more"] != true {
+		t.Errorf("has_more = %v, want true", out["has_more"])
+	}
+	if out["next_cursor"] != "cursor-abc" {
+		t.Errorf("next_cursor = %q, want cursor-abc", out["next_cursor"])
+	}
+}
+
+func TestNotionQueryDatabaseConnector_NoNextCursorWhenEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"results": []any{}, "next_cursor": "", "has_more": false,
+		})
+	}))
+	defer server.Close()
+
+	c := &NotionQueryDatabaseConnector{baseURL: server.URL}
+	out, err := c.Execute(context.Background(), map[string]any{
+		"database_id": "db-uuid-1",
+		"_credential": map[string]string{"token": "secret_test"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if _, exists := out["next_cursor"]; exists {
+		t.Error("next_cursor should be absent when empty")
+	}
+}
+
+func TestNotionQueryDatabaseConnector_MissingDatabaseID(t *testing.T) {
+	c := &NotionQueryDatabaseConnector{}
+	_, err := c.Execute(context.Background(), map[string]any{
+		"_credential": map[string]string{"token": "secret_test"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing database_id")
+	}
+}
+
+func TestNotionQueryDatabaseConnector_MissingCredential(t *testing.T) {
+	c := &NotionQueryDatabaseConnector{}
+	_, err := c.Execute(context.Background(), map[string]any{
+		"database_id": "db-uuid-1",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing credential")
+	}
+}
+
+func TestNotionQueryDatabaseConnector_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"object":"error","status":404,"message":"Could not find database."}`))
+	}))
+	defer server.Close()
+
+	c := &NotionQueryDatabaseConnector{baseURL: server.URL}
+	_, err := c.Execute(context.Background(), map[string]any{
+		"database_id": "nonexistent",
+		"_credential": map[string]string{"token": "secret_test"},
+	})
+	if err == nil {
+		t.Fatal("expected error for API error response")
+	}
+}
+
+func TestRegistry_NotionConnectors(t *testing.T) {
+	r := NewRegistry()
+	for _, action := range []string{"notion/create_page", "notion/query_database"} {
+		if _, err := r.Get(action); err != nil {
+			t.Errorf("Get(%q) error: %v", action, err)
+		}
+	}
+}

--- a/packages/engine/internal/connector/notion_test.go
+++ b/packages/engine/internal/connector/notion_test.go
@@ -389,6 +389,25 @@ func TestNotionQueryDatabaseConnector_NoNextCursorWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestNotionCreatePageConnector_MapAnyCredential(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(notionPageResponse())
+	}))
+	defer server.Close()
+
+	c := &NotionCreatePageConnector{baseURL: server.URL}
+	// Simulate a credential delivered as map[string]any (JSON/CEL-deserialised shape).
+	_, err := c.Execute(context.Background(), map[string]any{
+		"parent_database_id": "db-uuid-1",
+		"title":              "Test",
+		"_credential":        map[string]any{"token": "secret_test"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() with map[string]any credential: %v", err)
+	}
+}
+
 func TestNotionQueryDatabaseConnector_MissingDatabaseID(t *testing.T) {
 	c := &NotionQueryDatabaseConnector{}
 	_, err := c.Execute(context.Background(), map[string]any{

--- a/packages/engine/internal/connector/notion_test.go
+++ b/packages/engine/internal/connector/notion_test.go
@@ -159,6 +159,42 @@ func TestNotionCreatePageConnector_ExplicitPropertiesNotOverriddenByTitle(t *tes
 	}
 }
 
+func TestNotionCreatePageConnector_CustomTitleKey(t *testing.T) {
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(notionPageResponse())
+	}))
+	defer server.Close()
+
+	c := &NotionCreatePageConnector{baseURL: server.URL}
+	if _, err := c.Execute(context.Background(), map[string]any{
+		"parent_database_id": "db-uuid-1",
+		"title":              "My Task",
+		"title_key":          "Name",
+		"_credential":        map[string]string{"token": "secret_test"},
+	}); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	props, _ := gotBody["properties"].(map[string]any)
+	if _, hasTitle := props["title"]; hasTitle {
+		t.Error("properties should not contain key 'title' when title_key=Name")
+	}
+	nameProp, ok := props["Name"].(map[string]any)
+	if !ok {
+		t.Fatal("properties.Name missing or wrong type")
+	}
+	titleArr, _ := nameProp["title"].([]any)
+	text, _ := titleArr[0].(map[string]any)
+	textContent, _ := text["text"].(map[string]any)
+	if textContent["content"] != "My Task" {
+		t.Errorf("Name content = %q, want My Task", textContent["content"])
+	}
+}
+
 func TestNotionCreatePageConnector_MissingParent(t *testing.T) {
 	c := &NotionCreatePageConnector{}
 	_, err := c.Execute(context.Background(), map[string]any{


### PR DESCRIPTION
Closes #102

## What

Adds two native Notion connectors to the engine's built-in registry.

### `notion/create_page`
Creates a page inside a Notion database or as a child of another page.

| Param | Type | Notes |
|---|---|---|
| `parent_database_id` | string | Required if `parent_page_id` absent |
| `parent_page_id` | string | Required if `parent_database_id` absent |
| `title` | string | Shorthand — sets the `title` property; ignored if `properties` already contains `title` |
| `properties` | map | Full Notion property map (merged before title shorthand) |
| `children` | []any | Notion block objects for inline page content |
| `_credential` | `{token: "secret_..."}` | Integration token; deleted from params after use |

Returns: `id`, `url`, `created_time`, `last_edited_time`

### `notion/query_database`
Queries pages in a Notion database with optional filtering and pagination.

| Param | Type | Notes |
|---|---|---|
| `database_id` | string | Required |
| `filter` | map | Notion filter object |
| `sorts` | []any | Sort descriptors |
| `page_size` | int | Max results per page |
| `start_cursor` | string | Cursor for next page |
| `_credential` | `{token: "secret_..."}` | Integration token; deleted from params after use |

Returns: `results`, `count`, `has_more`, `next_cursor` (omitted when empty)

## Implementation notes

- Both connectors send `Authorization: Bearer {token}` and `Notion-Version: 2022-06-28`.
- `httpClient` and `toStringSlice` moved to `tools.go` as shared helpers (previously only on the unmerged `feat/github-linear-connectors` branch).
- 16 unit tests using `httptest` servers; all pass.

## Test plan

- [x] `go test ./internal/connector/ -run TestNotion` — 16/16 pass
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Two new Notion connectors added: create pages and query databases in Notion workspaces. Integrate Notion with your application workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dvflw/mantle/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->