### PR TITLE
fix(ci): resolve new govulncheck advisories (pgx bump + docker exclusions)

### DIFF
--- a/.changeset/govulncheck-advisories.md
+++ b/.changeset/govulncheck-advisories.md
@@ -1,0 +1,5 @@
+---
+"@mantle/engine": patch
+---
+
+Resolve new govulncheck advisories. Upgrade `github.com/jackc/pgx/v5` to v5.9.2, which fixes GO-2026-5004 (SQL injection via the non-default simple protocol with dollar-quoted literals). Add the three unfixable docker/docker `docker cp`/archive advisories (GO-2026-5617, GO-2026-5668, GO-2026-5746) to the CI govulncheck exclusion list, alongside the existing docker exclusions — docker/docker has no patched release (only moby/moby/v2), tracked by #151.

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -63,8 +63,10 @@ jobs:
         run: |
           # Known unfixable vulnerabilities — excluded from enforcement:
           #
-          # Indirect test-only dependency (docker/docker via testcontainers); no upstream fix:
+          # Indirect test-only dependency (docker/docker via testcontainers); no upstream fix
+          # (docker/docker and moby/moby have no fixed release; only moby/moby/v2 is patched):
           #   GO-2026-4887, GO-2026-4883
+          #   GO-2026-5617, GO-2026-5668, GO-2026-5746 (docker cp / archive host-path issues)
           #
           # Go standard library vulnerabilities fixed in go1.25.9 / go1.26.2 (released 2026-04-07).
           # Reachable in go < 1.25.9 via the listed call chains:
@@ -85,7 +87,7 @@ jobs:
           # Emit each actionable vulnerability ID as a GHA error annotation for visibility.
           ALL_IDS=$(echo "$OUTPUT" | grep -oE 'GO-[0-9]+-[0-9]+' | sort -u || true)
           echo "govulncheck IDs found: ${ALL_IDS:-none}"
-          KNOWN='GO-2026-4887|GO-2026-4883|GO-2026-4865|GO-2026-4869|GO-2026-4870|GO-2026-4946|GO-2026-4947|GO-2026-4918|GO-2026-4945|GO-2026-5013|GO-2026-5015|GO-2026-5017|GO-2026-5018|GO-2026-5019|GO-2026-5020|GO-2026-5021|GO-2026-5026'
+          KNOWN='GO-2026-4887|GO-2026-4883|GO-2026-5617|GO-2026-5668|GO-2026-5746|GO-2026-4865|GO-2026-4869|GO-2026-4870|GO-2026-4946|GO-2026-4947|GO-2026-4918|GO-2026-4945|GO-2026-5013|GO-2026-5015|GO-2026-5017|GO-2026-5018|GO-2026-5019|GO-2026-5020|GO-2026-5021|GO-2026-5026'
           ACTIONABLE_IDS=$(echo "$ALL_IDS" | grep -vE "^($KNOWN)$" || true)
           for ID in $ACTIONABLE_IDS; do
             echo "::error file=go.mod,line=1,title=Unfixed vulnerability::$ID — add to exclusion list or upgrade the affected dependency"

--- a/packages/engine/go.mod
+++ b/packages/engine/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/cel-go v0.27.0
 	github.com/googleapis/gax-go/v2 v2.15.0
-	github.com/jackc/pgx/v5 v5.9.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/microsoft/go-mssqldb v1.10.0
 	github.com/pressly/goose/v3 v3.27.0
 	github.com/prometheus/client_golang v1.23.2

--- a/packages/engine/go.sum
+++ b/packages/engine/go.sum
@@ -253,8 +253,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
-github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=


### PR DESCRIPTION
## Summary
Govulncheck started failing across the repo on four newly-published Go advisories in **existing** dependencies. The workflow runs `govulncheck@latest` against the live vuln DB, so these began failing on their own (independent of any code change) and affect `main` as well. This triages each: fix what's fixable, allowlist what isn't.

## Changes
- **`github.com/jackc/pgx/v5` v5.9.0 → v5.9.2** — fixes **GO-2026-5004** (SQL injection via the non-default simple protocol with dollar-quoted literals). This is a real, patched vulnerability, so it's fixed rather than suppressed.
- **Allowlist 3 docker/docker advisories** in the CI govulncheck exclusion list (`.github/workflows/engine-ci.yml`) — **GO-2026-5617, GO-2026-5668, GO-2026-5746** (`docker cp` / archive host-path issues). `docker/docker` and `moby/moby` have **no patched release** (only `moby/moby/v2` is fixed), so these join the existing docker/docker exclusions. The underlying dependency upgrade is tracked by #151.

## Testing
- [ ] `make test` — not affected (no engine logic changed); CI will run it
- [x] `make lint` — `go build ./...` passes with pgx v5.9.2
- [ ] New tests added — n/a (dependency + CI-config change)

## Related Issues
Relates to #151 (docker/docker upgrade). Unblocks Govulncheck on #162 and other open PRs once merged to `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WnKgCRfMvFcZAkoVbr8k79)_